### PR TITLE
changed for VC compiler and 32bit platform

### DIFF
--- a/libdivide.h
+++ b/libdivide.h
@@ -450,7 +450,7 @@ static inline int32_t libdivide__count_leading_zeros64(uint64_t val) {
 #else
     uint32_t hi = val >> 32;
     if (hi != 0) return libdivide__count_leading_zeros32(hi);
-    return 32 + libdivide__count_leading_zeros32(val & 0xFFFFFFFF);
+    return 32 + libdivide__count_leading_zeros32((uint32_t)val);
 #endif
 #else
     /* Dorky way to count leading zeros.  Note that this hangs for val = 0! */

--- a/libdivide.h
+++ b/libdivide.h
@@ -440,12 +440,18 @@ static inline int32_t libdivide__count_leading_zeros64(uint64_t val) {
 #if __GNUC__ || __has_builtin(__builtin_clzll)
     /* Fast way to count leading zeros */
     return __builtin_clzll(val);
-#elif LIBDIVIDE_VC && _WIN64
+#elif LIBDIVIDE_VC
+#ifdef _WIN64
     unsigned long result;
     if (_BitScanReverse64(&result, val)) {
         return 63 - result;
     }
     return 0;
+#else
+    uint32_t hi = val >> 32;
+    if (hi != 0) return libdivide__count_leading_zeros32(hi);
+    return 32 + libdivide__count_leading_zeros32(val & 0xFFFFFFFF);
+#endif
 #else
     /* Dorky way to count leading zeros.  Note that this hangs for val = 0! */
     int32_t result = 0;


### PR DESCRIPTION
For VC compiler and 32bit platform, function libdivide__count_leading_zeros64 changed to use _BitScanReverse intinsic function instead of while loop. Tested only on Windows CE 6.0 ARM Cortex A8 and libdivide::divider<unsigned __int64l> perfoms about 10-20% faster than the original implementation. The _BitScanReverse is not implemented under CE VC2008 and was implemented by me in separate file as 31-_CountLeadingZeros.