### PR TITLE
Fix error in 'release' section of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ x86_64: libdivide_test.cpp libdivide.h
 	$(CPP) $(DEBUG_FLAGS) $(ARCH_x64) -o tester libdivide_test.cpp $(LINKFLAGS)
 
 release: libdivide_test.cpp libdivide.h
-	$(CPP) $(RELEASE_FLAGS) $(ARCH_x64) $(ARCH_386) -o tester libdivide_test.cpp $(LINKFLAGS)p
+	$(CPP) $(RELEASE_FLAGS) $(ARCH_x64) $(ARCH_386) -o tester libdivide_test.cpp $(LINKFLAGS)
 
 benchmark: libdivide_benchmark.c libdivide.h
 	$(CC) $(RELEASE_FLAGS) $(ARCH_x64) $(ARCH_386) -o benchmark libdivide_benchmark.c $(LINKFLAGS)


### PR DESCRIPTION
Extra 'p' at end of compiler invocation caused build process to fail.
