### PR TITLE
Clean up comments

### DIFF
--- a/libdivide.h
+++ b/libdivide.h
@@ -770,8 +770,8 @@ struct libdivide_u32_t libdivide_u32_gen(uint32_t d) {
 }
     
 struct libdivide_u32_branchfree_t libdivide_u32_branchfree_gen(uint32_t d) {
-    struct libdivide_u32_t tmp = libdivide_internal_u32_gen(d, 1);
-    struct libdivide_u32_branchfree_t ret = {tmp.magic, tmp.more & LIBDIVIDE_32_SHIFT_MASK};
+    struct libdivide_u32_t tmp = libdivide_internal_u32_gen(d, 1);)
+    struct libdivide_u32_branchfree_t ret = {tmp.magic, (uint8_t)(tmp.more & LIBDIVIDE_32_SHIFT_MASK)};
     return ret;
 }
 
@@ -830,7 +830,7 @@ uint32_t libdivide_u32_recover(const struct libdivide_u32_t *denom) {
 }
 
 uint32_t libdivide_u32_branchfree_recover(const struct libdivide_u32_branchfree_t *denom) {
-    struct libdivide_u32_t denom_u32 = {denom->magic, denom->more | LIBDIVIDE_ADD_MARKER};
+    struct libdivide_u32_t denom_u32 = {denom->magic, (uint8_t)(denom->more | LIBDIVIDE_ADD_MARKER)};
     return libdivide_u32_recover(&denom_u32);
 }
 
@@ -966,7 +966,7 @@ struct libdivide_u64_t libdivide_u64_gen(uint64_t d)
 struct libdivide_u64_branchfree_t libdivide_u64_branchfree_gen(uint64_t d)
 {
     struct libdivide_u64_t tmp = libdivide_internal_u64_gen(d, 1);
-    struct libdivide_u64_branchfree_t ret = {tmp.magic, tmp.more & LIBDIVIDE_64_SHIFT_MASK};
+    struct libdivide_u64_branchfree_t ret = {tmp.magic, (uint8_t)(tmp.more & LIBDIVIDE_64_SHIFT_MASK)};
     return ret;
 }
 
@@ -1036,7 +1036,7 @@ uint64_t libdivide_u64_recover(const struct libdivide_u64_t *denom) {
 }
 
 uint64_t libdivide_u64_branchfree_recover(const struct libdivide_u64_branchfree_t *denom) {
-    struct libdivide_u64_t denom_u64 = {denom->magic, denom->more | LIBDIVIDE_ADD_MARKER};
+    struct libdivide_u64_t denom_u64 = {denom->magic, (uint8_t)(denom->more | LIBDIVIDE_ADD_MARKER)};
     return libdivide_u64_recover(&denom_u64);
 }
     

--- a/libdivide.h
+++ b/libdivide.h
@@ -1,6 +1,5 @@
-/* libdivide.h
-   Copyright 2010 ridiculous_fish
-*/
+// libdivide.h
+// Copyright 2010 - 2016 ridiculous_fish
 
 #if defined(_WIN32) || defined(WIN32)
 #define LIBDIVIDE_WINDOWS 1
@@ -21,7 +20,7 @@
 #endif
 
 #if ! LIBDIVIDE_HAS_STDINT_TYPES && (! LIBDIVIDE_VC || _MSC_VER >= 1600)
-/* Only Visual C++ 2010 and later include stdint.h */
+// Only Visual C++ 2010 and later include stdint.h
 #include <stdint.h>
 #define LIBDIVIDE_HAS_STDINT_TYPES 1
 #endif
@@ -44,7 +43,7 @@ typedef unsigned __int8 uint8_t;
 #endif
 
 #ifndef __has_builtin
-#define __has_builtin(x) 0  // Compatibility with non-clang compilers.
+#define __has_builtin(x) 0 // Compatibility with non-clang compilers.
 #endif
 
 #if defined(__SIZEOF_INT128__)
@@ -69,48 +68,55 @@ typedef unsigned __int8 uint8_t;
 #define LIBDIVIDE_ASSERT(x)
 #endif
 
-
-/* libdivide may use the pmuldq (vector signed 32x32->64 mult instruction) which is in SSE 4.1.  However, signed multiplication can be emulated efficiently with unsigned multiplication, and SSE 4.1 is currently rare, so it is OK to not turn this on */
+// libdivide may use the pmuldq (vector signed 32x32->64 mult instruction)
+// which is in SSE 4.1. However, signed multiplication can be emulated
+// efficiently with unsigned multiplication, and SSE 4.1 is currently rare,
+// so it is OK to not turn this on.
 #ifdef LIBDIVIDE_USE_SSE4_1
 #include <smmintrin.h>
 #endif
 
-/* Silly defines to prevent Xcode indenting */
+// Silly defines to prevent Xcode indenting
 #define LIBDIVIDE_OPEN_BRACKET {
 #define LIBDIVIDE_CLOSE_BRACKET }
 
 #ifdef __cplusplus
-/* We place libdivide within the libdivide namespace, and that goes in an anonymous namespace so that the functions are only visible to files that #include this header and don't get external linkage.  At least that's the theory. */
+// We place libdivide within the libdivide namespace, and that goes in an
+// anonymous namespace so that the functions are only visible to files that
+// #include this header and don't get external linkage. At least that's the
+// theory.
 namespace LIBDIVIDE_OPEN_BRACKET
 namespace libdivide LIBDIVIDE_OPEN_BRACKET
 #endif
 
-/* Explanation of "more" field: bit 6 is whether to use shift path.  If we are using the shift path, bit 7 is whether the divisor is negative in the signed case; in the unsigned case it is 0.   Bits 0-4 is shift value (for shift path or mult path).  In 32 bit case, bit 5 is always 0.  We use bit 7 as the "negative divisor indicator" so that we can use sign extension to efficiently go to a full-width -1.
-
-
-u32: [0-4] shift value
-     [5] ignored
-     [6] add indicator
-     [7] shift path
-     
-s32: [0-4] shift value
-     [5] shift path
-     [6] add indicator
-     [7] indicates negative divisor
-
-u64: [0-5] shift value
-     [6] add indicator
-     [7] shift path
-
-s64: [0-5] shift value
-     [6] add indicator
-     [7] indicates negative divisor
-     magic number of 0 indicates shift path (we ran out of bits!)
- 
-
-In s32 and s64 branchfree modes, the magic number is negated according to whether the divisor is negated. In branchfree strategy, it is not negated.
- 
-*/
+// Explanation of "more" field: bit 6 is whether to use shift path.  If we are
+// using the shift path, bit 7 is whether the divisor is negative in the signed
+// case; in the unsigned case it is 0.   Bits 0-4 is shift value (for shift
+// path or mult path).  In 32 bit case, bit 5 is always 0.  We use bit 7 as the
+// "negative divisor indicator" so that we can use sign extension to
+// efficiently go to a full-width -1.
+//
+// u32: [0-4] shift value
+//      [5] ignored
+//      [6] add indicator
+//      [7] shift path
+//
+// s32: [0-4] shift value
+//      [5] shift path
+//      [6] add indicator
+//      [7] indicates negative divisor
+//
+// u64: [0-5] shift value
+//      [6] add indicator
+//      [7] shift path
+//
+// s64: [0-5] shift value
+//      [6] add indicator
+//      [7] indicates negative divisor
+//      magic number of 0 indicates shift path (we ran out of bits!)
+//
+// In s32 and s64 branchfree modes, the magic number is negated according to
+// whether the divisor is negated. In branchfree strategy, it is not negated.
 
 enum {
     LIBDIVIDE_32_SHIFT_MASK = 0x1F,
@@ -121,7 +127,6 @@ enum {
     LIBDIVIDE_S32_SHIFT_PATH = 0x20,
     LIBDIVIDE_NEGATIVE_DIVISOR = 0x80    
 };
-
 
 struct libdivide_u32_t {
     uint32_t magic;
@@ -163,16 +168,17 @@ struct libdivide_s64_branchfree_t {
     uint8_t more;
 };
 
-
 #ifndef LIBDIVIDE_API
     #ifdef __cplusplus
-        /* In C++, we don't want our public functions to be static, because they are arguments to templates and static functions can't do that.  They get internal linkage through virtue of the anonymous namespace.  In C, they should be static. */
+        // In C++, we don't want our public functions to be static, because
+        // they are arguments to templates and static functions can't do that.
+        // They get internal linkage through virtue of the anonymous namespace.
+        // In C, they should be static.
         #define LIBDIVIDE_API
     #else
         #define LIBDIVIDE_API static inline
     #endif
 #endif
-
 
 LIBDIVIDE_API struct libdivide_s32_t libdivide_s32_gen(int32_t y);
 LIBDIVIDE_API struct libdivide_u32_t libdivide_u32_gen(uint32_t y);
@@ -199,9 +205,9 @@ LIBDIVIDE_API uint32_t libdivide_u32_recover(const struct libdivide_u32_t *denom
 LIBDIVIDE_API int64_t  libdivide_s64_recover(const struct libdivide_s64_t *denom);
 LIBDIVIDE_API uint64_t libdivide_u64_recover(const struct libdivide_u64_t *denom);
 
-LIBDIVIDE_API int32_t libdivide_s32_branchfree_recover(const struct libdivide_s32_branchfree_t *denom);
+LIBDIVIDE_API int32_t  libdivide_s32_branchfree_recover(const struct libdivide_s32_branchfree_t *denom);
 LIBDIVIDE_API uint32_t libdivide_u32_branchfree_recover(const struct libdivide_u32_branchfree_t *denom);
-LIBDIVIDE_API int64_t libdivide_s64_branchfree_recover(const struct libdivide_s64_branchfree_t *denom);
+LIBDIVIDE_API int64_t  libdivide_s64_branchfree_recover(const struct libdivide_s64_branchfree_t *denom);
 LIBDIVIDE_API uint64_t libdivide_u64_branchfree_recover(const struct libdivide_u64_branchfree_t *denom);
 
 LIBDIVIDE_API int libdivide_u32_get_algorithm(const struct libdivide_u32_t *denom);
@@ -260,9 +266,7 @@ LIBDIVIDE_API __m128i libdivide_u64_branchfree_do_vector(__m128i numers, const s
 LIBDIVIDE_API __m128i libdivide_s64_branchfree_do_vector(__m128i numers, const struct libdivide_s64_branchfree_t * denom);
 
 #endif
- 
- 
- 
+
 //////// Internal Utility Functions
 
 enum libdivide_internal_strategy_t {
@@ -291,7 +295,7 @@ static uint64_t libdivide__mullhi_u64(uint64_t x, uint64_t y) {
     __uint128_t rl = xl * yl;
     return (uint64_t)(rl >> 64);
 #else
-    //full 128 bits are x0 * y0 + (x0 * y1 << 32) + (x1 * y0 << 32) + (x1 * y1 << 64)
+    // full 128 bits are x0 * y0 + (x0 * y1 << 32) + (x1 * y0 << 32) + (x1 * y1 << 64)
     const uint32_t mask = 0xFFFFFFFF;
     const uint32_t x0 = (uint32_t)(x & mask), x1 = (uint32_t)(x >> 32);
     const uint32_t y0 = (uint32_t)(y & mask), y1 = (uint32_t)(y >> 32);
@@ -312,7 +316,7 @@ static inline int64_t libdivide__mullhi_s64(int64_t x, int64_t y) {
     __int128_t rl = xl * yl;
     return (int64_t)(rl >> 64);    
 #else
-    //full 128 bits are x0 * y0 + (x0 * y1 << 32) + (x1 * y0 << 32) + (x1 * y1 << 64)
+    // full 128 bits are x0 * y0 + (x0 * y1 << 32) + (x1 * y0 << 32) + (x1 * y1 << 64)
     const uint32_t mask = 0xFFFFFFFF;
     const uint32_t x0 = (uint32_t)(x & mask), y0 = (uint32_t)(y & mask);
     const int32_t x1 = (int32_t)(x >> 32), y1 = (int32_t)(y >> 32);
@@ -327,7 +331,8 @@ static inline int64_t libdivide__mullhi_s64(int64_t x, int64_t y) {
 
 static inline __m128i libdivide__u64_to_m128(uint64_t x) {
 #if LIBDIVIDE_VC && ! _WIN64
-    //64 bit windows doesn't seem to have an implementation of any of these load intrinsics, and 32 bit Visual C++ crashes
+    // 64 bit windows doesn't seem to have an implementation of any of these
+    // load intrinsics, and 32 bit Visual C++ crashes
     _declspec(align(16)) uint64_t temp[2] = {x, x};
     return _mm_load_si128((const __m128i*)temp);
 #elif defined(__ICC)
@@ -343,32 +348,41 @@ static inline __m128i libdivide__u64_to_m128(uint64_t x) {
 }
 
 static inline __m128i libdivide_get_FFFFFFFF00000000(void) {
-    //returns the same as _mm_set1_epi64(0xFFFFFFFF00000000ULL) without touching memory
-    __m128i result = _mm_set1_epi8(-1); //optimizes to pcmpeqd on OS X
+    // returns the same as _mm_set1_epi64(0xFFFFFFFF00000000ULL)
+    // without touching memory.
+    __m128i result = _mm_set1_epi8(-1); // optimizes to pcmpeqd on OS X
     return _mm_slli_epi64(result, 32);
 }
     
 static inline __m128i libdivide_get_00000000FFFFFFFF(void) {
-    //returns the same as _mm_set1_epi64(0x00000000FFFFFFFFULL) without touching memory
-    __m128i result = _mm_set1_epi8(-1); //optimizes to pcmpeqd on OS X
+    // returns the same as _mm_set1_epi64(0x00000000FFFFFFFFULL)
+    // without touching memory.
+    __m128i result = _mm_set1_epi8(-1); // optimizes to pcmpeqd on OS X
     result = _mm_srli_epi64(result, 32);
     return result;
 }
 
 static inline __m128i libdivide_s64_signbits(__m128i v) {
-    //we want to compute v >> 63, that is, _mm_srai_epi64(v, 63).  But there is no 64 bit shift right arithmetic instruction in SSE2.  So we have to fake it by first duplicating the high 32 bit values, and then using a 32 bit shift.  Another option would be to use _mm_srli_epi64(v, 63) and then subtract that from 0, but that approach appears to be substantially slower for unknown reasons
+    // we want to compute v >> 63, that is, _mm_srai_epi64(v, 63).  But there
+    // is no 64 bit shift right arithmetic instruction in SSE2.  So we have to
+    // fake it by first duplicating the high 32 bit values, and then using a 32
+    // bit shift.  Another option would be to use _mm_srli_epi64(v, 63) and
+    // then subtract that from 0, but that approach appears to be substantially
+    // slower for unknown reasons
     __m128i hiBitsDuped = _mm_shuffle_epi32(v, _MM_SHUFFLE(3, 3, 1, 1));
     __m128i signBits = _mm_srai_epi32(hiBitsDuped, 31);
     return signBits;
 }
 
-/* Returns an __m128i whose low 32 bits are equal to amt and has zero elsewhere. */
+// Returns an __m128i whose low 32 bits are equal to amt and has zero elsewhere.
 static inline __m128i libdivide_u32_to_m128i(uint32_t amt) {
     return _mm_set_epi32(0, 0, 0, amt);
 }
     
 static inline __m128i libdivide_s64_shift_right_vector(__m128i v, int amt) {
-    //implementation of _mm_sra_epi64.  Here we have two 64 bit values which are shifted right to logically become (64 - amt) values, and are then sign extended from a (64 - amt) bit number.
+    // implementation of _mm_sra_epi64.  Here we have two 64 bit values which
+    // are shifted right to logically become (64 - amt) values, and are then
+    // sign extended from a (64 - amt) bit number.
     const int b = 64 - amt;
     __m128i m = libdivide__u64_to_m128(1ULL << (b - 1));
     __m128i x = _mm_srl_epi64(v, libdivide_u32_to_m128i(amt));
@@ -376,7 +390,8 @@ static inline __m128i libdivide_s64_shift_right_vector(__m128i v, int amt) {
     return result;
 }
 
-/* Here, b is assumed to contain one 32 bit value repeated four times.  If it did not, the function would not work. */
+// Here, b is assumed to contain one 32 bit value repeated four times. If it
+// did not, the function would not work.
 static inline __m128i libdivide__mullhi_u32_flat_vector(__m128i a, __m128i b) {
     __m128i hi_product_0Z2Z = _mm_srli_epi64(_mm_mul_epu32(a, b), 32);
     __m128i a1X3X = _mm_srli_epi64(a, 32);
@@ -385,13 +400,17 @@ static inline __m128i libdivide__mullhi_u32_flat_vector(__m128i a, __m128i b) {
 }
 
     
-/* Here, y is assumed to contain one 64 bit value repeated twice. */
+// Here, y is assumed to contain one 64 bit value repeated twice.
 static inline __m128i libdivide_mullhi_u64_flat_vector(__m128i x, __m128i y) {
-    //full 128 bits are x0 * y0 + (x0 * y1 << 32) + (x1 * y0 << 32) + (x1 * y1 << 64)
+    // full 128 bits are x0 * y0 + (x0 * y1 << 32) + (x1 * y0 << 32) + (x1 * y1 << 64)
     const __m128i mask = libdivide_get_00000000FFFFFFFF();
-    const __m128i x0 = _mm_and_si128(x, mask), x1 = _mm_srli_epi64(x, 32); //x0 is low half of 2 64 bit values, x1 is high half in low slots
+    // x0 is low half of 2 64 bit values, x1 is high half in low slots
+    const __m128i x0 = _mm_and_si128(x, mask), x1 = _mm_srli_epi64(x, 32);
     const __m128i y0 = _mm_and_si128(y, mask), y1 = _mm_srli_epi64(y, 32);
-    const __m128i x0y0_hi = _mm_srli_epi64(_mm_mul_epu32(x0, y0), 32); //x0 happens to have the low half of the two 64 bit values in 32 bit slots 0 and 2, so _mm_mul_epu32 computes their full product, and then we shift right by 32 to get just the high values
+    // x0 happens to have the low half of the two 64 bit values in 32 bit slots
+    // 0 and 2, so _mm_mul_epu32 computes their full product, and then we shift
+    // right by 32 to get just the high values
+    const __m128i x0y0_hi = _mm_srli_epi64(_mm_mul_epu32(x0, y0), 32);
     const __m128i x0y1 = _mm_mul_epu32(x0, y1);
     const __m128i x1y0 = _mm_mul_epu32(x1, y0);
     const __m128i x1y1 = _mm_mul_epu32(x1, y1);
@@ -404,7 +423,7 @@ static inline __m128i libdivide_mullhi_u64_flat_vector(__m128i x, __m128i y) {
     return _mm_add_epi64(temp_lo, temp_hi);
 }
 
-/* y is one 64 bit value repeated twice */
+// y is one 64 bit value repeated twice
 static inline __m128i libdivide_mullhi_s64_flat_vector(__m128i x, __m128i y) {
     __m128i p = libdivide_mullhi_u64_flat_vector(x, y);
     __m128i t1 = _mm_and_si128(libdivide_s64_signbits(x), y);
@@ -416,7 +435,7 @@ static inline __m128i libdivide_mullhi_s64_flat_vector(__m128i x, __m128i y) {
     
 #ifdef LIBDIVIDE_USE_SSE4_1
     
-/* b is one 32 bit value repeated four times. */
+// b is one 32 bit value repeated four times.
 static inline __m128i libdivide_mullhi_s32_flat_vector(__m128i a, __m128i b) {
     __m128i hi_product_0Z2Z = _mm_srli_epi64(_mm_mul_epi32(a, b), 32);
     __m128i a1X3X = _mm_srli_epi64(a, 32);
@@ -426,10 +445,12 @@ static inline __m128i libdivide_mullhi_s32_flat_vector(__m128i a, __m128i b) {
     
 #else
 
-/* SSE2 does not have a signed multiplication instruction, but we can convert unsigned to signed pretty efficiently.  Again, b is just a 32 bit value repeated four times. */
+// SSE2 does not have a signed multiplication instruction, but we can convert
+// unsigned to signed pretty efficiently.  Again, b is just a 32 bit value
+// repeated four times.
 static inline __m128i libdivide_mullhi_s32_flat_vector(__m128i a, __m128i b) {
     __m128i p = libdivide__mullhi_u32_flat_vector(a, b);
-    __m128i t1 = _mm_and_si128(_mm_srai_epi32(a, 31), b); //t1 = (a >> 31) & y, arithmetic shift
+    __m128i t1 = _mm_and_si128(_mm_srai_epi32(a, 31), b); // t1 = (a >> 31) & y, arithmetic shift
     __m128i t2 = _mm_and_si128(_mm_srai_epi32(b, 31), a);
     p = _mm_sub_epi32(p, t1);
     p = _mm_sub_epi32(p, t2);
@@ -440,7 +461,7 @@ static inline __m128i libdivide_mullhi_s32_flat_vector(__m128i a, __m128i b) {
  
 static inline int32_t libdivide__count_trailing_zeros32(uint32_t val) {
 #if __GNUC__ || __has_builtin(__builtin_ctz)
-    /* Fast way to count trailing zeros */
+    // Fast way to count trailing zeros
     return __builtin_ctz(val);
 #elif LIBDIVIDE_VC
     unsigned long result;
@@ -449,9 +470,9 @@ static inline int32_t libdivide__count_trailing_zeros32(uint32_t val) {
     }
     return 0;
 #else
-    /* Dorky way to count trailing zeros.   Note that this hangs for val = 0! */
+    // Dorky way to count trailing zeros. Note that this hangs for val = 0!
     int32_t result = 0;
-    val = (val ^ (val - 1)) >> 1;  // Set v's trailing 0s to 1s and zero rest
+    val = (val ^ (val - 1)) >> 1; // Set v's trailing 0s to 1s and zero rest
     while (val) {
         val >>= 1;
         result++;
@@ -462,7 +483,9 @@ static inline int32_t libdivide__count_trailing_zeros32(uint32_t val) {
  
 static inline int32_t libdivide__count_trailing_zeros64(uint64_t val) {
 #if __LP64__ && (__GNUC__ || __has_builtin(__builtin_ctzll))
-    /* Fast way to count trailing zeros.  Note that we disable this in 32 bit because gcc does something horrible - it calls through to a dynamically bound function. */
+    // Fast way to count trailing zeros.
+    // Note that we disable this in 32 bit because gcc does something horrible,
+    // it calls through to a dynamically bound function.
     return __builtin_ctzll(val);
 #elif LIBDIVIDE_VC && _WIN64
     unsigned long result;
@@ -471,7 +494,8 @@ static inline int32_t libdivide__count_trailing_zeros64(uint64_t val) {
     }
     return 0;
 #else
-    /* Pretty good way to count trailing zeros.  Note that this hangs for val = 0! */
+    // Pretty good way to count trailing zeros.
+    // Note that this hangs for val = 0!
     uint32_t lo = val & 0xFFFFFFFF;
     if (lo != 0) return libdivide__count_trailing_zeros32(lo);
     return 32 + libdivide__count_trailing_zeros32(val >> 32);
@@ -480,7 +504,7 @@ static inline int32_t libdivide__count_trailing_zeros64(uint64_t val) {
  
 static inline int32_t libdivide__count_leading_zeros32(uint32_t val) {
 #if __GNUC__ || __has_builtin(__builtin_clzll)
-    /* Fast way to count leading zeros */
+    // Fast way to count leading zeros
     return __builtin_clz(val);    
 #elif LIBDIVIDE_VC
     unsigned long result;
@@ -489,7 +513,8 @@ static inline int32_t libdivide__count_leading_zeros32(uint32_t val) {
     }
     return 0;
 #else
-    /* Dorky way to count leading zeros.  Note that this hangs for val = 0! */
+    // Dorky way to count leading zeros.
+    // Note that this hangs for val = 0!
     int32_t result = 0;
     while (! (val & (1U << 31))) {
         val <<= 1;
@@ -501,7 +526,7 @@ static inline int32_t libdivide__count_leading_zeros32(uint32_t val) {
     
 static inline int32_t libdivide__count_leading_zeros64(uint64_t val) {
 #if __GNUC__ || __has_builtin(__builtin_clzll)
-    /* Fast way to count leading zeros */
+    // Fast way to count leading zeros
     return __builtin_clzll(val);
 #elif LIBDIVIDE_VC && _WIN64
     unsigned long result;
@@ -510,7 +535,8 @@ static inline int32_t libdivide__count_leading_zeros64(uint64_t val) {
     }
     return 0;
 #else
-    /* Dorky way to count leading zeros.  Note that this hangs for val = 0! */
+    // Dorky way to count leading zeros.
+    // Note that this hangs for val = 0!
     int32_t result = 0;
     while (! (val & (1ULL << 63))) {
         val <<= 1;
@@ -520,7 +546,9 @@ static inline int32_t libdivide__count_leading_zeros64(uint64_t val) {
 #endif
 }
 
-//libdivide_64_div_32_to_32: divides a 64 bit uint {u1, u0} by a 32 bit uint {v}.  The result must fit in 32 bits.  Returns the quotient directly and the remainder in *r
+// libdivide_64_div_32_to_32: divides a 64 bit uint {u1, u0} by a 32 bit
+// uint {v}. The result must fit in 32 bits. Returns the quotient directly and
+// the remainder in *r
 #if (LIBDIVIDE_IS_i386 || LIBDIVIDE_IS_X86_64) && LIBDIVIDE_GCC_STYLE_ASM
 static uint32_t libdivide_64_div_32_to_32(uint32_t u1, uint32_t u0, uint32_t v, uint32_t *r) {
     uint32_t result;
@@ -541,9 +569,9 @@ static uint32_t libdivide_64_div_32_to_32(uint32_t u1, uint32_t u0, uint32_t v, 
     
 #if LIBDIVIDE_IS_X86_64 && LIBDIVIDE_GCC_STYLE_ASM
 static uint64_t libdivide_128_div_64_to_64(uint64_t u1, uint64_t u0, uint64_t v, uint64_t *r) {
-    //u0 -> rax
-    //u1 -> rdx
-    //divq
+    // u0 -> rax
+    // u1 -> rdx
+    // divq
     uint64_t result;
     __asm__("divq %[v]"
             : "=a"(result), "=d"(*r)
@@ -553,9 +581,12 @@ static uint64_t libdivide_128_div_64_to_64(uint64_t u1, uint64_t u0, uint64_t v,
 
 }
 #else
- 
-/* Code taken from Hacker's Delight, http://www.hackersdelight.org/HDcode/divlu.c .  License permits inclusion here per http://www.hackersdelight.org/permissions.htm
- */
+
+// Code taken from Hacker's Delight:
+// http://www.hackersdelight.org/HDcode/divlu.c.
+// License permits inclusion here per:
+// http://www.hackersdelight.org/permissions.htm
+
 static uint64_t libdivide_128_div_64_to_64(uint64_t u1, uint64_t u0, uint64_t v, uint64_t *r) {    
     const uint64_t b = (1ULL << 32); // Number base (16 bits).
     uint64_t un1, un0,        // Norm. dividend LSD's.
@@ -570,7 +601,7 @@ static uint64_t libdivide_128_div_64_to_64(uint64_t u1, uint64_t u0, uint64_t v,
             *r = (uint64_t)(-1);    // and return the largest
         return (uint64_t)(-1);}    // possible quotient.
     
-    /* count leading zeros */
+    // count leading zeros
     s = libdivide__count_leading_zeros64(v); // 0 <= s <= 63.
     if (s > 0) {
         v = v << s;           // Normalize divisor.
@@ -628,7 +659,7 @@ static inline void libdivide_u128_shift(uint64_t *u1, uint64_t *u0, int32_t sign
     }
 }
     
-/* Computes a 128 / 128 -> 64 bit division, with a 128 bit remainder. */
+// Computes a 128 / 128 -> 64 bit division, with a 128 bit remainder.
 static uint64_t libdivide_128_div_128_to_64(uint64_t u_hi, uint64_t u_lo, uint64_t v_hi, uint64_t v_lo, uint64_t *r_hi, uint64_t *r_lo) {
 #if HAS_INT128_T
     __uint128_t ufull = u_hi;
@@ -647,8 +678,9 @@ static uint64_t libdivide_128_div_128_to_64(uint64_t u_hi, uint64_t u_lo, uint64
     u128_t v = {v_hi, v_lo};
     if (v.hi == 0) {
         // divisor v is a 64 bit value, so we just need one 128/64 division
-        // Note that we are simpler than Hacker's Delight here, because we know the quotient fits in 64 bits
-        // whereas Hacker's Delight demands a full 128 bit quotient
+        // Note that we are simpler than Hacker's Delight here, because we know
+        // the quotient fits in 64 bits whereas Hacker's Delight demands a full
+        // 128 bit quotient
         *r_hi = 0;
         return libdivide_128_div_64_to_64(u.hi, u.lo, v.lo, r_lo);
     }
@@ -723,7 +755,7 @@ static uint64_t libdivide_128_div_128_to_64(uint64_t u_hi, uint64_t u_lo, uint64
 ////////// UINT32
 
 static inline struct libdivide_u32_t libdivide_internal_u32_gen(uint32_t d, int branchfree) {
-    /* 1 is not supported with branchfree algorithm */
+    // 1 is not supported with branchfree algorithm
     LIBDIVIDE_ASSERT(!branchfree || d != 1);
 
     struct libdivide_u32_t result;
@@ -735,7 +767,8 @@ static inline struct libdivide_u32_t libdivide_internal_u32_gen(uint32_t d, int 
             result.more = floor_log_2_d | LIBDIVIDE_U32_SHIFT_PATH;
         } else {
             // We want a magic number of 2**32 and a shift of floor_log_2_d
-            // but one of the shifts is taken up by LIBDIVIDE_ADD_MARKER, so we subtract 1 from the shift
+            // but one of the shifts is taken up by LIBDIVIDE_ADD_MARKER, so we
+            // subtract 1 from the shift
             result.magic = 0;
             result.more = (floor_log_2_d-1) | LIBDIVIDE_ADD_MARKER;
         }
@@ -747,20 +780,27 @@ static inline struct libdivide_u32_t libdivide_internal_u32_gen(uint32_t d, int 
         LIBDIVIDE_ASSERT(rem > 0 && rem < d);
         const uint32_t e = d - rem;
         
-        /* This power works if e < 2**floor_log_2_d. */
+        // This power works if e < 2**floor_log_2_d.
         if (!branchfree && (e < (1U << floor_log_2_d))) {
-            /* This power works */
+            // This power works
             more = floor_log_2_d;
         } else {
-            /* We have to use the general 33-bit algorithm.  We need to compute (2**power) / d. However, we already have (2**(power-1))/d and its remainder.  By doubling both, and then correcting the remainder, we can compute the larger division. */
-            proposed_m += proposed_m; //don't care about overflow here - in fact, we expect it
+            // We have to use the general 33-bit algorithm.  We need to compute
+            // (2**power) / d. However, we already have (2**(power-1))/d and
+            // its remainder.  By doubling both, and then correcting the
+            // remainder, we can compute the larger division.
+            proposed_m += proposed_m; // don't care about overflow here - in fact, we expect it
             const uint32_t twice_rem = rem + rem;
             if (twice_rem >= d || twice_rem < rem) proposed_m += 1;
             more = floor_log_2_d | LIBDIVIDE_ADD_MARKER;
         }
         result.magic = 1 + proposed_m;
         result.more = more;
-        //result.more's shift should in general be ceil_log_2_d.  But if we used the smaller power, we subtract one from the shift because we're using the smaller power. If we're using the larger power, we subtract one from the shift because it's taken care of by the add indicator.  So floor_log_2_d happens to be correct in both cases.
+        // result.more's shift should in general be ceil_log_2_d.  But if we
+        // used the smaller power, we subtract one from the shift because we're
+        // using the smaller power. If we're using the larger power, we
+        // subtract one from the shift because it's taken care of by the add
+        // indicator. So floor_log_2_d happens to be correct in both cases.
     }
     return result;
 }
@@ -775,7 +815,6 @@ struct libdivide_u32_branchfree_t libdivide_u32_branchfree_gen(uint32_t d) {
     return ret;
 }
 
-
 uint32_t libdivide_u32_do(uint32_t numer, const struct libdivide_u32_t *denom) {
     uint8_t more = denom->more;
     if (more & LIBDIVIDE_U32_SHIFT_PATH) {
@@ -788,7 +827,7 @@ uint32_t libdivide_u32_do(uint32_t numer, const struct libdivide_u32_t *denom) {
             return t >> (more & LIBDIVIDE_32_SHIFT_MASK);
         }
         else {
-            return q >> more; //all upper bits are 0 - don't need to mask them off
+            return q >> more; // all upper bits are 0 - don't need to mask them off
         }
     }
 }
@@ -808,18 +847,21 @@ uint32_t libdivide_u32_recover(const struct libdivide_u32_t *denom) {
         uint32_t rem_ignored;
         return 1 + libdivide_64_div_32_to_32(hi_dividend, 0, denom->magic, &rem_ignored);
     } else {
-        // Here we wish to compute d = 2^(32+shift+1)/(m+2^32). Notice (m + 2^32) is a 33 bit number
-        // Use 64 bit division for now
-        // Also note that shift may be as high as 31, so shift + 1 will overflow
-        // So we have to compute it as 2^(32+shift)/(m+2^32), and then double the quotient and remainder
+        // Here we wish to compute d = 2^(32+shift+1)/(m+2^32).
+        // Notice (m + 2^32) is a 33 bit number. Use 64 bit division for now
+        // Also note that shift may be as high as 31, so shift + 1 will
+        // overflow. So we have to compute it as 2^(32+shift)/(m+2^32), and
+        // then double the quotient and remainder.
         // TODO: do something better than 64 bit math
         uint64_t half_n = 1LLU << (32 + shift);
         uint64_t d = (1LLU << 32) | denom->magic;
-        // Note that the quotient is guaranteed <= 32 bits, but the remainder may need 33!
+        // Note that the quotient is guaranteed <= 32 bits, but the remainder
+        // may need 33!
         uint32_t half_q = (uint32_t)(half_n / d);
         uint64_t rem = half_n % d;
         // We computed 2^(32+shift)/(m+2^32)
-        // Need to double it, and then add 1 to the quotient if doubling the remainder would increase the quotient
+        // Need to double it, and then add 1 to the quotient if doubling th
+        // remainder would increase the quotient.
         // Note that rem<<1 cannot overflow, since rem < d and d is 33 bits
         uint32_t full_q = half_q + half_q + ((rem<<1) >= d);
         
@@ -854,8 +896,8 @@ uint32_t libdivide_u32_do_alg2(uint32_t numer, const struct libdivide_u32_t *den
     // denom->add != 0
     uint32_t q = libdivide__mullhi_u32(denom->magic, numer);
     uint32_t t = ((numer - q) >> 1) + q;
-    // Note that this mask is typically free. Only the low bits are meaningful to a shift, so
-    // compilers can optimize out this AND.
+    // Note that this mask is typically free. Only the low bits are meaningful
+    // to a shift, so compilers can optimize out this AND.
     return t >> (denom->more & LIBDIVIDE_32_SHIFT_MASK);
 }
 
@@ -865,7 +907,6 @@ uint32_t libdivide_u32_branchfree_do(uint32_t numer, const struct libdivide_u32_
     uint32_t t = ((numer - q) >> 1) + q;
     return t >> denom->more;
 }
-
     
 #if LIBDIVIDE_USE_SSE2    
 __m128i libdivide_u32_do_vector(__m128i numers, const struct libdivide_u32_t *denom) {
@@ -876,14 +917,14 @@ __m128i libdivide_u32_do_vector(__m128i numers, const struct libdivide_u32_t *de
     else {
         __m128i q = libdivide__mullhi_u32_flat_vector(numers, _mm_set1_epi32(denom->magic));
         if (more & LIBDIVIDE_ADD_MARKER) {
-            //uint32_t t = ((numer - q) >> 1) + q;
-            //return t >> denom->shift;
+            // uint32_t t = ((numer - q) >> 1) + q;
+            // return t >> denom->shift;
             __m128i t = _mm_add_epi32(_mm_srli_epi32(_mm_sub_epi32(numers, q), 1), q);
             return _mm_srl_epi32(t, libdivide_u32_to_m128i(more & LIBDIVIDE_32_SHIFT_MASK));
             
         }
         else {
-            //q >> denom->shift
+            // q >> denom->shift
             return _mm_srl_epi32(q, libdivide_u32_to_m128i(more));
         }
     }
@@ -916,7 +957,7 @@ LIBDIVIDE_API __m128i libdivide_u32_branchfree_do_vector(__m128i numers, const s
 /////////// UINT64
 
 static inline struct libdivide_u64_t libdivide_internal_u64_gen(uint64_t d, int branchfree) {
-    /* 1 is not supported with branchfree algorithm */
+    // 1 is not supported with branchfree algorithm
     LIBDIVIDE_ASSERT(!branchfree || d != 1);
     
     struct libdivide_u64_t result;
@@ -928,7 +969,8 @@ static inline struct libdivide_u64_t libdivide_internal_u64_gen(uint64_t d, int 
             result.more = floor_log_2_d | LIBDIVIDE_U64_SHIFT_PATH;
         } else {
             // We want a magic number of 2**64 and a shift of floor_log_2_d
-            // but one of the shifts is taken up by LIBDIVIDE_ADD_MARKER, so we subtract 1 from the shift
+            // but one of the shifts is taken up by LIBDIVIDE_ADD_MARKER, so we
+            // subtract 1 from the shift
             result.magic = 0;
             result.more = (floor_log_2_d-1) | LIBDIVIDE_ADD_MARKER;
         }
@@ -940,20 +982,28 @@ static inline struct libdivide_u64_t libdivide_internal_u64_gen(uint64_t d, int 
         LIBDIVIDE_ASSERT(rem > 0 && rem < d);
         const uint64_t e = d - rem;
         
-        /* This power works if e < 2**floor_log_2_d. */
+        // This power works if e < 2**floor_log_2_d.
         if (!branchfree && e < (1ULL << floor_log_2_d)) {
-            /* This power works */
+            // This power works
             more = floor_log_2_d;
         } else {
-            /* We have to use the general 65-bit algorithm.  We need to compute (2**power) / d. However, we already have (2**(power-1))/d and its remainder.  By doubling both, and then correcting the remainder, we can compute the larger division. */
-            proposed_m += proposed_m; //don't care about overflow here - in fact, we expect it
+            // We have to use the general 65-bit algorithm.  We need to compute
+            // (2**power) / d. However, we already have (2**(power-1))/d and
+            // its remainder.  By doubling both, and then correcting the
+            // remainder, we can compute the larger division.
+            proposed_m += proposed_m; // don't care about overflow here - in fact, we expect it
             const uint64_t twice_rem = rem + rem;
             if (twice_rem >= d || twice_rem < rem) proposed_m += 1;
                 more = floor_log_2_d | LIBDIVIDE_ADD_MARKER;
                 }
         result.magic = 1 + proposed_m;
         result.more = more;
-        //result.more's shift should in general be ceil_log_2_d.  But if we used the smaller power, we subtract one from the shift because we're using the smaller power. If we're using the larger power, we subtract one from the shift because it's taken care of by the add indicator.  So floor_log_2_d happens to be correct in both cases, which is why we do it outside of the if statement.
+        // result.more's shift should in general be ceil_log_2_d.  But if we
+        // used the smaller power, we subtract one from the shift because we're
+        // using the smaller power. If we're using the larger power, we
+        // subtract one from the shift because it's taken care of by the add
+        // indicator. So floor_log_2_d happens to be correct in both cases,
+        // which is why we do it outside of the if statement.
     }
     return result;
 }
@@ -982,11 +1032,10 @@ uint64_t libdivide_u64_do(uint64_t numer, const struct libdivide_u64_t *denom) {
             return t >> (more & LIBDIVIDE_64_SHIFT_MASK);
         }
         else {
-            return q >> more; //all upper bits are 0 - don't need to mask them off
+            return q >> more; // all upper bits are 0 - don't need to mask them off
         }
     }
 }
-
 
 uint64_t libdivide_u64_recover(const struct libdivide_u64_t *denom) {
     uint8_t more = denom->more;
@@ -1003,8 +1052,9 @@ uint64_t libdivide_u64_recover(const struct libdivide_u64_t *denom) {
         uint64_t rem_ignored;
         return 1 + libdivide_128_div_64_to_64(hi_dividend, 0, denom->magic, &rem_ignored);
     } else {
-        // Here we wish to compute d = 2^(64+shift+1)/(m+2^64). Notice (m + 2^64) is a 65 bit number
-        // This gets hairy. See libdivide_u32_recover for more on what we do here
+        // Here we wish to compute d = 2^(64+shift+1)/(m+2^64).
+        // Notice (m + 2^64) is a 65 bit number. This gets hairy. See
+        // libdivide_u32_recover for more on what we do here.
         // TODO: do something better than 128 bit math
         
         // Hack: if d is not a power of 2, this is a 128/128->64 divide
@@ -1021,12 +1071,14 @@ uint64_t libdivide_u64_recover(const struct libdivide_u64_t *denom) {
         uint64_t half_n_hi = 1LLU << shift, half_n_lo = 0;
         // d is a 65 bit value. The high bit is always set to 1.
         const uint64_t d_hi = 1, d_lo = denom->magic;
-        // Note that the quotient is guaranteed <= 64 bits, but the remainder may need 65!
+        // Note that the quotient is guaranteed <= 64 bits,
+        // but the remainder may need 65!
         uint64_t r_hi, r_lo;
         uint64_t half_q = libdivide_128_div_128_to_64(half_n_hi, half_n_lo, d_hi, d_lo, &r_hi, &r_lo);
         // We computed 2^(64+shift)/(m+2^64)
         // Double the remainder ('dr') and check if that is larger than d
-        // Note that d is a 65 bit value, so r1 is small and so r1 + r1 cannot overflow
+        // Note that d is a 65 bit value, so r1 is small and so r1 + r1 cannot
+        // overflow
         uint64_t dr_lo = r_lo + r_lo;
         uint64_t dr_hi = r_hi + r_hi + (dr_lo < r_lo); // last term is carry
         int dr_exceeds_d = (dr_hi > d_hi) || (dr_hi == d_hi && dr_lo >= d_lo);        
@@ -1078,13 +1130,13 @@ __m128i libdivide_u64_do_vector(__m128i numers, const struct libdivide_u64_t * d
     else {
         __m128i q = libdivide_mullhi_u64_flat_vector(numers, libdivide__u64_to_m128(denom->magic));
         if (more & LIBDIVIDE_ADD_MARKER) {
-            //uint32_t t = ((numer - q) >> 1) + q;
-            //return t >> denom->shift;
+            // uint32_t t = ((numer - q) >> 1) + q;
+            // return t >> denom->shift;
             __m128i t = _mm_add_epi64(_mm_srli_epi64(_mm_sub_epi64(numers, q), 1), q);
             return _mm_srl_epi64(t, libdivide_u32_to_m128i(more & LIBDIVIDE_64_SHIFT_MASK));
         }
         else {
-            //q >> denom->shift
+            // q >> denom->shift
             return _mm_srl_epi64(q, libdivide_u32_to_m128i(more));
         }
     }
@@ -1114,12 +1166,11 @@ __m128i libdivide_u64_branchfree_do_vector(__m128i numers, const struct libdivid
 #endif
  
 /////////// SINT32
- 
 
 static inline int32_t libdivide__mullhi_s32(int32_t x, int32_t y) {
     int64_t xl = x, yl = y;
     int64_t rl = xl * yl;
-    return (int32_t)(rl >> 32); //needs to be arithmetic shift
+    return (int32_t)(rl >> 32); // needs to be arithmetic shift
 }
 
 static inline struct libdivide_s32_t libdivide_internal_s32_gen(int32_t d, int branchfree) {
@@ -1128,11 +1179,16 @@ static inline struct libdivide_s32_t libdivide_internal_s32_gen(int32_t d, int b
     
     struct libdivide_s32_t result;
     
-    /* If d is a power of 2, or negative a power of 2, we have to use a shift.  This is especially important because the magic algorithm fails for -1.  To check if d is a power of 2 or its inverse, it suffices to check whether its absolute value has exactly one bit set.  This works even for INT_MIN, because abs(INT_MIN) == INT_MIN, and INT_MIN has one bit set and is a power of 2.  */
+    // If d is a power of 2, or negative a power of 2, we have to use a shift.
+    // This is especially important because the magic algorithm fails for -1.
+    // To check if d is a power of 2 or its inverse, it suffices to check
+    // whether its absolute value has exactly one bit set.  This works even for
+    // INT_MIN, because abs(INT_MIN) == INT_MIN, and INT_MIN has one bit set
+    // and is a power of 2.
     uint32_t ud = (uint32_t)d;
-    uint32_t absD = (d < 0 ? -ud : ud); //gcc optimizes this to the fast abs trick
+    uint32_t absD = (d < 0 ? -ud : ud); // gcc optimizes this to the fast abs trick
     const uint32_t floor_log_2_d = 31 - libdivide__count_leading_zeros32(absD);
-    if ((absD & (absD - 1)) == 0) { //check if exactly one bit is set, don't care if absD is 0 since that's divide by zero
+    if ((absD & (absD - 1)) == 0) { // check if exactly one bit is set, don't care if absD is 0 since that's divide by zero
         // Branchfree and normal paths are exactly the same
         result.magic = 0;
         result.more = floor_log_2_d | (d < 0 ? LIBDIVIDE_NEGATIVE_DIVISOR : 0) | LIBDIVIDE_S32_SHIFT_PATH;
@@ -1140,17 +1196,21 @@ static inline struct libdivide_s32_t libdivide_internal_s32_gen(int32_t d, int b
         LIBDIVIDE_ASSERT(floor_log_2_d >= 1);    
         
         uint8_t more;
-        //the dividend here is 2**(floor_log_2_d + 31), so the low 32 bit word is 0 and the high word is floor_log_2_d - 1
+        // the dividend here is 2**(floor_log_2_d + 31), so the low 32 bit word
+        // is 0 and the high word is floor_log_2_d - 1
         uint32_t rem, proposed_m;
         proposed_m = libdivide_64_div_32_to_32(1U << (floor_log_2_d - 1), 0, absD, &rem);
         const uint32_t e = absD - rem;
         
-        /* We are going to start with a power of floor_log_2_d - 1.  This works if works if e < 2**floor_log_2_d. */
+        // We are going to start with a power of floor_log_2_d - 1.
+        // This works if works if e < 2**floor_log_2_d.
         if (!branchfree && e < (1U << floor_log_2_d)) {
-            /* This power works */
+            // This power works
             more = floor_log_2_d - 1;
         } else {
-            /* We need to go one higher.  This should not make proposed_m overflow, but it will make it negative when interpreted as an int32_t. */
+            // We need to go one higher. This should not make proposed_m
+            // overflow, but it will make it negative when interpreted as an
+            // int32_t.
             proposed_m += proposed_m;
             const uint32_t twice_rem = rem + rem;
             if (twice_rem >= absD || twice_rem < rem) proposed_m += 1;
@@ -1160,7 +1220,8 @@ static inline struct libdivide_s32_t libdivide_internal_s32_gen(int32_t d, int b
         proposed_m += 1;
         int32_t magic = (int32_t)proposed_m;
         
-        /* Mark if we are negative. Note we only negate the magic number in the branchfull case. */
+        // Mark if we are negative. Note we only negate the magic number in the
+        // branchfull case.
         if (d < 0) {
             more |= LIBDIVIDE_NEGATIVE_DIVISOR;
             if (! branchfree) {
@@ -1197,8 +1258,10 @@ int32_t libdivide_s32_do(int32_t numer, const struct libdivide_s32_t *denom) {
     } else {
         uint32_t uq = (uint32_t)libdivide__mullhi_s32(denom->magic, numer);
         if (more & LIBDIVIDE_ADD_MARKER) {
-            int32_t sign = (int8_t)more >> 7; //must be arithmetic shift and then sign extend
-            uq += (((uint32_t)numer ^ sign) - sign); // q += (more < 0 ? -numer : numer), casts to avoid UB
+            // must be arithmetic shift and then sign extend
+            int32_t sign = (int8_t)more >> 7;
+            // q += (more < 0 ? -numer : numer), casts to avoid UB
+            uq += (((uint32_t)numer ^ sign) - sign);
         }
         int32_t q = (int32_t)uq;
         q >>= more & LIBDIVIDE_32_SHIFT_MASK;
@@ -1210,14 +1273,16 @@ int32_t libdivide_s32_do(int32_t numer, const struct libdivide_s32_t *denom) {
 int32_t libdivide_s32_branchfree_do(int32_t numer, const struct libdivide_s32_branchfree_t *denom) {
     uint8_t more = denom->more;
     uint8_t shift = more & LIBDIVIDE_32_SHIFT_MASK;
-    int32_t sign = (int8_t)more >> 7; //must be arithmetic shift and then sign extend
+    // must be arithmetic shift and then sign extend
+    int32_t sign = (int8_t)more >> 7;
     
     int32_t magic = denom->magic;
     int32_t q = libdivide__mullhi_s32(magic, numer);
     q += numer;
     
     // If q is non-negative, we have nothing to do
-    // If q is negative, we want to add either (2**shift)-1 if d is a power of 2, or (2**shift) if it is not a power of 2
+    // If q is negative, we want to add either (2**shift)-1 if d is a power of
+    // 2, or (2**shift) if it is not a power of 2
     uint32_t is_power_of_2 = !!(more & LIBDIVIDE_S32_SHIFT_PATH);
     uint32_t q_sign = (uint32_t)(q >> 31);
     q += q_sign & ((1 << shift) - is_power_of_2);
@@ -1230,7 +1295,6 @@ int32_t libdivide_s32_branchfree_do(int32_t numer, const struct libdivide_s32_br
     
     return q;
 }
-
 
 int32_t libdivide_s32_recover(const struct libdivide_s32_t *denom) {
     uint8_t more = denom->more;
@@ -1248,11 +1312,12 @@ int32_t libdivide_s32_recover(const struct libdivide_s32_t *denom) {
         return (int32_t)absD;
     } else {
         // Unsigned math is much easier
-        // We negate the magic number only in the branchfull case, and we don't know which case we're in
-        // However we have enough information to determine the correct sign of the magic number
-        // The divisor was negative iff LIBDIVIDE_NEGATIVE_DIVISOR is set
-        // If ADD_MARKER is set, the magic number's sign is opposite that of the divisor
-        // We want to compute the positive magic number
+        // We negate the magic number only in the branchfull case, and we don't
+        // know which case we're in. However we have enough information to
+        // determine the correct sign of the magic number. The divisor was
+        // negative if LIBDIVIDE_NEGATIVE_DIVISOR is set.  If ADD_MARKER is
+        // set, the magic number's sign is opposite that of the divisor.
+        // We want to compute the positive magic number.
         int negative_divisor = (more & LIBDIVIDE_NEGATIVE_DIVISOR);
         int magic_was_negated = (more & LIBDIVIDE_ADD_MARKER) ? denom->magic > 0 : denom->magic < 0;
         
@@ -1323,17 +1388,17 @@ __m128i libdivide_s32_do_vector(__m128i numers, const struct libdivide_s32_t * d
     uint8_t more = denom->more;
     if (more & LIBDIVIDE_S32_SHIFT_PATH) {
         uint32_t shifter = more & LIBDIVIDE_32_SHIFT_MASK;
-        __m128i roundToZeroTweak = _mm_set1_epi32((1U << shifter) - 1); //could use _mm_srli_epi32 with an all -1 register
+        __m128i roundToZeroTweak = _mm_set1_epi32((1U << shifter) - 1); // could use _mm_srli_epi32 with an all -1 register
         __m128i q = _mm_add_epi32(numers, _mm_and_si128(_mm_srai_epi32(numers, 31), roundToZeroTweak)); //q = numer + ((numer >> 31) & roundToZeroTweak);
         q = _mm_sra_epi32(q, libdivide_u32_to_m128i(shifter)); // q = q >> shifter
-        __m128i shiftMask = _mm_set1_epi32((int32_t)((int8_t)more >> 7)); //set all bits of shift mask = to the sign bit of more
-        q = _mm_sub_epi32(_mm_xor_si128(q, shiftMask), shiftMask); //q = (q ^ shiftMask) - shiftMask;
+        __m128i shiftMask = _mm_set1_epi32((int32_t)((int8_t)more >> 7)); // set all bits of shift mask = to the sign bit of more
+        q = _mm_sub_epi32(_mm_xor_si128(q, shiftMask), shiftMask); // q = (q ^ shiftMask) - shiftMask;
         return q;
     }
     else {
         __m128i q = libdivide_mullhi_s32_flat_vector(numers, _mm_set1_epi32(denom->magic));
         if (more & LIBDIVIDE_ADD_MARKER) {
-            __m128i sign = _mm_set1_epi32((int32_t)(int8_t)more >> 7); //must be arithmetic shift
+            __m128i sign = _mm_set1_epi32((int32_t)(int8_t)more >> 7); // must be arithmetic shift
             q = _mm_add_epi32(q, _mm_sub_epi32(_mm_xor_si128(numers, sign), sign)); // q += ((numer ^ sign) - sign);
         }
         q = _mm_sra_epi32(q, libdivide_u32_to_m128i(more & LIBDIVIDE_32_SHIFT_MASK)); //q >>= shift
@@ -1384,13 +1449,15 @@ __m128i libdivide_s32_branchfree_do_vector(__m128i numers, const struct libdivid
     int32_t magic = denom->magic;
     uint8_t more = denom->more;
     uint8_t shift = more & LIBDIVIDE_32_SHIFT_MASK;
-    __m128i sign = _mm_set1_epi32((int32_t)(int8_t)more >> 7); //must be arithmetic shift
-    
-    __m128i q = libdivide_mullhi_s32_flat_vector(numers, _mm_set1_epi32(magic)); // libdivide__mullhi_s32(numers, magic);
+    __m128i sign = _mm_set1_epi32((int32_t)(int8_t)more >> 7); // must be arithmetic shift
+
+     // libdivide__mullhi_s32(numers, magic);
+    __m128i q = libdivide_mullhi_s32_flat_vector(numers, _mm_set1_epi32(magic));
     q = _mm_add_epi32(q, numers); // q += numers
     
     // If q is non-negative, we have nothing to do
-    // If q is negative, we want to add either (2**shift)-1 if d is a power of 2, or (2**shift) if it is not a power of 2
+    // If q is negative, we want to add either (2**shift)-1 if d is a power of
+    // 2, or (2**shift) if it is not a power of 2
     uint32_t is_power_of_2 = (magic == 0);
     __m128i q_sign = _mm_srai_epi32(q, 31); // q_sign = q >> 31
     q = _mm_add_epi32(q, _mm_and_si128(q_sign, _mm_set1_epi32((1 << shift) - is_power_of_2))); // q = q + (q_sign & ((1 << shift) - is_power_of_2)
@@ -1401,39 +1468,48 @@ __m128i libdivide_s32_branchfree_do_vector(__m128i numers, const struct libdivid
 #endif
 
 ///////////// SINT64
- 
 
 static inline struct libdivide_s64_t libdivide_internal_s64_gen(int64_t d, int branchfree) {
     LIBDIVIDE_ASSERT(!branchfree || (d != 1 && d != -1));
     struct libdivide_s64_t result;
     
-    /* If d is a power of 2, or negative a power of 2, we have to use a shift.  This is especially important because the magic algorithm fails for -1.  To check if d is a power of 2 or its inverse, it suffices to check whether its absolute value has exactly one bit set.  This works even for INT_MIN, because abs(INT_MIN) == INT_MIN, and INT_MIN has one bit set and is a power of 2.  */
+    // If d is a power of 2, or negative a power of 2, we have to use a shift.
+    // This is especially important because the magic algorithm fails for -1.
+    // To check if d is a power of 2 or its inverse, it suffices to check
+    // whether its absolute value has exactly one bit set.  This works even for
+    // INT_MIN, because abs(INT_MIN) == INT_MIN, and INT_MIN has one bit set
+    // and is a power of 2.
     const uint64_t ud = (uint64_t)d;
-    const uint64_t absD = (d < 0 ? -ud : ud); //gcc optimizes this to the fast abs trick
+    const uint64_t absD = (d < 0 ? -ud : ud); // gcc optimizes this to the fast abs trick
     const uint32_t floor_log_2_d = 63 - libdivide__count_leading_zeros64(absD);
-    if ((absD & (absD - 1)) == 0) { //check if exactly one bit is set, don't care if absD is 0 since that's divide by zero
+    if ((absD & (absD - 1)) == 0) { // check if exactly one bit is set, don't care if absD is 0 since that's divide by zero
         // Branchfree and non-branchfree cases are the same
         result.magic = 0;
         result.more = floor_log_2_d | (d < 0 ? LIBDIVIDE_NEGATIVE_DIVISOR : 0);
     } else {
-        //the dividend here is 2**(floor_log_2_d + 63), so the low 64 bit word is 0 and the high word is floor_log_2_d - 1
+        // the dividend here is 2**(floor_log_2_d + 63), so the low 64 bit word
+        // is 0 and the high word is floor_log_2_d - 1
         uint8_t more;
         uint64_t rem, proposed_m;
         proposed_m = libdivide_128_div_64_to_64(1ULL << (floor_log_2_d - 1), 0, absD, &rem);
         const uint64_t e = absD - rem;
         
-        /* We are going to start with a power of floor_log_2_d - 1.  This works if works if e < 2**floor_log_2_d. */
+        // We are going to start with a power of floor_log_2_d - 1.
+        // This works if works if e < 2**floor_log_2_d.
         if (!branchfree && e < (1ULL << floor_log_2_d)) {
-            /* This power works */
+            // This power works
             more = floor_log_2_d - 1;
         } else {
-            /* We need to go one higher.  This should not make proposed_m overflow, but it will make it negative when interpreted as an int32_t. */
+            // We need to go one higher. This should not make proposed_m
+            // overflow, but it will make it negative when interpreted as an
+            // int32_t.
             proposed_m += proposed_m;
             const uint64_t twice_rem = rem + rem;
             if (twice_rem >= absD || twice_rem < rem) proposed_m += 1;
-            // note that we only set the LIBDIVIDE_NEGATIVE_DIVISOR bit if we also set ADD_MARKER
-            // this is an annoying optimization that enables algorithm #4 to avoid the mask.
-            // however we always set it in the branchfree case
+            // note that we only set the LIBDIVIDE_NEGATIVE_DIVISOR bit if we
+            // also set ADD_MARKER this is an annoying optimization that
+            // enables algorithm #4 to avoid the mask. However we always set it
+            // in the branchfree case
             more = floor_log_2_d | LIBDIVIDE_ADD_MARKER;
         }
         proposed_m += 1;
@@ -1471,13 +1547,15 @@ int64_t libdivide_s64_do(int64_t numer, const struct libdivide_s64_t *denom) {
         uint64_t uq = (uint64_t)numer + ((numer >> 63) & ((1ULL << shifter) - 1));
         int64_t q = (int64_t)uq;
         q = q >> shifter;
-        int64_t shiftMask = (int8_t)more >> 7; //must be arithmetic shift and then sign-extend
+        // must be arithmetic shift and then sign-extend
+        int64_t shiftMask = (int8_t)more >> 7;
         q = (q ^ shiftMask) - shiftMask;
         return q;
     } else {
         uint64_t uq = (uint64_t)libdivide__mullhi_s64(magic, numer);
         if (more & LIBDIVIDE_ADD_MARKER) {
-            int64_t sign = (int8_t)more >> 7; //must be arithmetic shift and then sign extend
+            // must be arithmetic shift and then sign extend
+            int64_t sign = (int8_t)more >> 7;
             uq += (((uint64_t)numer ^ sign) - sign);
         }
         int64_t q = (int64_t)uq;
@@ -1490,15 +1568,17 @@ int64_t libdivide_s64_do(int64_t numer, const struct libdivide_s64_t *denom) {
 int64_t libdivide_s64_branchfree_do(int64_t numer, const struct libdivide_s64_branchfree_t *denom) {
     uint8_t more = denom->more;
     uint32_t shift = more & LIBDIVIDE_64_SHIFT_MASK;
-    int64_t sign = (int8_t)more >> 7; //must be arithmetic shift and then sign extend
+    // must be arithmetic shift and then sign extend
+    int64_t sign = (int8_t)more >> 7;
     
     int64_t magic = denom->magic;
     
     int64_t q = libdivide__mullhi_s64(magic, numer);
     q += numer;
     
-    // If q is non-negative, we have nothing to do
-    // If q is negative, we want to add either (2**shift)-1 if d is a power of 2, or (2**shift) if it is not a power of 2
+    // If q is non-negative, we have nothing to do.
+    // If q is negative, we want to add either (2**shift)-1 if d is a power of
+    // 2, or (2**shift) if it is not a power of 2.
     uint32_t is_power_of_2 = (magic == 0);
     uint64_t q_sign = (uint64_t)(q >> 63);
     q += q_sign & ((1LLU << shift) - is_power_of_2);
@@ -1549,7 +1629,7 @@ int64_t libdivide_s64_branchfree_recover(const struct libdivide_s64_branchfree_t
 int libdivide_s64_get_algorithm(const struct libdivide_s64_t *denom) {
     uint8_t more = denom->more;
     int positiveDivisor = ! (more & LIBDIVIDE_NEGATIVE_DIVISOR);
-    if (denom->magic == 0) return (positiveDivisor ? 0 : 1); //shift path
+    if (denom->magic == 0) return (positiveDivisor ? 0 : 1); // shift path
     else if (more & LIBDIVIDE_ADD_MARKER) return (positiveDivisor ? 2 : 3);
     else return 4;
 }
@@ -1561,7 +1641,7 @@ int64_t libdivide_s64_do_alg0(int64_t numer, const struct libdivide_s64_t *denom
 }
  
 int64_t libdivide_s64_do_alg1(int64_t numer, const struct libdivide_s64_t *denom) {
-    //denom->shifter != -1 && demo->shiftMask != 0
+    // denom->shifter != -1 && demo->shiftMask != 0
     uint32_t shifter = denom->more & LIBDIVIDE_64_SHIFT_MASK;
     int64_t q = numer + ((numer >> 63) & ((1ULL << shifter) - 1));
     return - (q >> shifter);
@@ -1590,27 +1670,26 @@ int64_t libdivide_s64_do_alg4(int64_t numer, const struct libdivide_s64_t *denom
     return q;   
 }
 
-
 #if LIBDIVIDE_USE_SSE2
 __m128i libdivide_s64_do_vector(__m128i numers, const struct libdivide_s64_t * denom) {
     uint8_t more = denom->more;
     int64_t magic = denom->magic;
-    if (magic == 0) { //shift path
+    if (magic == 0) { // shift path
         uint32_t shifter = more & LIBDIVIDE_64_SHIFT_MASK;
         __m128i roundToZeroTweak = libdivide__u64_to_m128((1ULL << shifter) - 1);
-        __m128i q = _mm_add_epi64(numers, _mm_and_si128(libdivide_s64_signbits(numers), roundToZeroTweak)); //q = numer + ((numer >> 63) & roundToZeroTweak);
+        __m128i q = _mm_add_epi64(numers, _mm_and_si128(libdivide_s64_signbits(numers), roundToZeroTweak)); // q = numer + ((numer >> 63) & roundToZeroTweak);
         q = libdivide_s64_shift_right_vector(q, shifter); // q = q >> shifter
         __m128i shiftMask = _mm_set1_epi32((int32_t)((int8_t)more >> 7));
-        q = _mm_sub_epi64(_mm_xor_si128(q, shiftMask), shiftMask); //q = (q ^ shiftMask) - shiftMask;
+        q = _mm_sub_epi64(_mm_xor_si128(q, shiftMask), shiftMask); // q = (q ^ shiftMask) - shiftMask;
         return q;
     }
     else {
         __m128i q = libdivide_mullhi_s64_flat_vector(numers, libdivide__u64_to_m128(magic));
         if (more & LIBDIVIDE_ADD_MARKER) {
-            __m128i sign = _mm_set1_epi32((int32_t)((int8_t)more >> 7)); //must be arithmetic shift
+            __m128i sign = _mm_set1_epi32((int32_t)((int8_t)more >> 7)); // must be arithmetic shift
             q = _mm_add_epi64(q, _mm_sub_epi64(_mm_xor_si128(numers, sign), sign)); // q += ((numer ^ sign) - sign);        
         }
-        q = libdivide_s64_shift_right_vector(q, more & LIBDIVIDE_64_SHIFT_MASK); //q >>= denom->mult_path.shift
+        q = libdivide_s64_shift_right_vector(q, more & LIBDIVIDE_64_SHIFT_MASK); // q >>= denom->mult_path.shift
         q = _mm_add_epi64(q, _mm_srli_epi64(q, 63)); // q += (q < 0)
         return q;
     }
@@ -1660,17 +1739,19 @@ __m128i libdivide_s64_branchfree_do_vector(__m128i numers, const struct libdivid
     int64_t magic = denom->magic;
     uint8_t more = denom->more;
     uint8_t shift = more & LIBDIVIDE_64_SHIFT_MASK;
-    __m128i sign = _mm_set1_epi32((int32_t)(int8_t)more >> 7); //must be arithmetic shift
-    
-    __m128i q = libdivide_mullhi_s64_flat_vector(numers, libdivide__u64_to_m128(magic)); // libdivide__mullhi_s64(numers, magic);
+    __m128i sign = _mm_set1_epi32((int32_t)(int8_t)more >> 7); // must be arithmetic shift
+
+     // libdivide__mullhi_s64(numers, magic);
+    __m128i q = libdivide_mullhi_s64_flat_vector(numers, libdivide__u64_to_m128(magic));
     q = _mm_add_epi64(q, numers); // q += numers
     
-    // If q is non-negative, we have nothing to do
-    // If q is negative, we want to add either (2**shift)-1 if d is a power of 2, or (2**shift) if it is not a power of 2
+    // If q is non-negative, we have nothing to do.
+    // If q is negative, we want to add either (2**shift)-1 if d is a power of
+    // 2, or (2**shift) if it is not a power of 2.
     uint32_t is_power_of_2 = (magic == 0);
     __m128i q_sign = libdivide_s64_signbits(q); // q_sign = q >> 63
     q = _mm_add_epi64(q, _mm_and_si128(q_sign, libdivide__u64_to_m128((1ULL << shift) - is_power_of_2))); // q = q + (q_sign & ((1 << shift) - is_power_of_2)
-    q = libdivide_s64_shift_right_vector(q, shift); //q >>= shift
+    q = libdivide_s64_shift_right_vector(q, shift); // q >>= shift
     q = _mm_sub_epi64(_mm_xor_si128(q, sign), sign); // q = (q ^ sign) - sign
     return q;
 }
@@ -1681,10 +1762,9 @@ __m128i libdivide_s64_branchfree_do_vector(__m128i numers, const struct libdivid
  
 #ifdef __cplusplus
 
-/* Our divider struct is templated on both a type (like uint64_t) and an algorithm index.
-   BRANCHFULL is the default algorithm, BRANCHFREE is the branchfree variant, and the indexed variants
-   are for unswitching.
-*/
+// Our divider struct is templated on both a type (like uint64_t) and an
+// algorithm index. BRANCHFULL is the default algorithm, BRANCHFREE is the
+// branchfree variant, and the indexed variants are for unswitching.
 enum {
     BRANCHFULL = -1,
     BRANCHFREE = -2,
@@ -1706,7 +1786,8 @@ namespace libdivide_internal {
 #define MAYBE_VECTOR_PARAM(X) int vector_func
 #endif
 
-    /* Some bogus unswitch functions for unsigned types so the same (presumably templated) code can work for both signed and unsigned. */
+    // Some bogus unswitch functions for unsigned types so the same
+    // (presumably templated) code can work for both signed and unsigned.
     uint32_t crash_u32(uint32_t, const libdivide_u32_t *) { abort(); return *(uint32_t *)NULL; }
     uint64_t crash_u64(uint64_t, const libdivide_u64_t *) { abort(); return *(uint64_t *)NULL; }
 #if LIBDIVIDE_USE_SSE2
@@ -1714,37 +1795,37 @@ namespace libdivide_internal {
     __m128i crash_u64_vector(__m128i, const libdivide_u64_t *) { abort(); return *(__m128i *)NULL; }
 #endif
 
-    /* Base divider, which provides storage for the actual divider */
+    // Base divider, which provides storage for the actual divider
     template<typename IntType, // like uint32_t
              typename DenomType, // like libdivide_u32_t
              DenomType gen_func(IntType), // like libdivide_u32_gen
              IntType do_func(IntType, const DenomType *), // like libdivide_u32_do
              MAYBE_VECTOR_PARAM(DenomType)> // like libdivide_u32_do_vector
     struct base {
-        /* Storage for the actual divider */
+        // Storage for the actual divider
         DenomType denom;
         
-        /* Constructor that takes a divisor value, and applies the gen function */
+        // Constructor that takes a divisor value, and applies the gen function
         base(IntType d) : denom(gen_func(d)) { }
         
-        /* Copy constructor */
+        // Copy constructor
         base(const DenomType & d) : denom(d) { }
         
-        /* Default constructor to allow uninitialized uses in e.g. arrays */
+        // Default constructor to allow uninitialized uses in e.g. arrays
         base() {}
         
-        /* Scalar divide */
+        // Scalar divide
         IntType perform_divide(IntType val) const { return do_func(val, &denom); }
         
 #if LIBDIVIDE_USE_SSE2
-        /* Vector divide */
+        // Vector divide
         __m128i perform_divide_vector(__m128i val) const { return vector_func(val, &denom); }
 #endif
     };
     
-    /* Type-specific dispatch */
+    // Type-specific dispatch
     
-    /* uint32 */
+    // uint32
     template<uint32_t do_func(uint32_t, const libdivide_u32_t*),
              MAYBE_VECTOR_PARAM(libdivide_u32_t),
              libdivide_u32_t gen_func(uint32_t) = libdivide_u32_gen>
@@ -1758,7 +1839,7 @@ namespace libdivide_internal {
     template<> struct algo_u32<ALGORITHM2> { typedef denom_u32<libdivide_u32_do_alg2, MAYBE_VECTOR(libdivide_u32_do_vector_alg2)>::divider divider; };
     template<> struct algo_u32<BRANCHFREE> { typedef base<uint32_t, libdivide_u32_branchfree_t, libdivide_u32_branchfree_gen, libdivide_u32_branchfree_do, MAYBE_VECTOR(libdivide_u32_branchfree_do_vector)> divider;  };
     
-    /* uint64 */
+    // uint64
     template<uint64_t do_func(uint64_t, const libdivide_u64_t*),
              MAYBE_VECTOR_PARAM(libdivide_u64_t),
              libdivide_u64_t gen_func(uint64_t) = libdivide_u64_gen>
@@ -1771,9 +1852,8 @@ namespace libdivide_internal {
     template<> struct algo_u64<ALGORITHM1> { typedef denom_u64<libdivide_u64_do_alg1, MAYBE_VECTOR(libdivide_u64_do_vector_alg1)>::divider divider; };
     template<> struct algo_u64<ALGORITHM2> { typedef denom_u64<libdivide_u64_do_alg2, MAYBE_VECTOR(libdivide_u64_do_vector_alg2)>::divider divider; };
     template<> struct algo_u64<BRANCHFREE> { typedef base<uint64_t, libdivide_u64_branchfree_t, libdivide_u64_branchfree_gen, libdivide_u64_branchfree_do, MAYBE_VECTOR(libdivide_u64_branchfree_do_vector)> divider;  };
-    
-
-    /* int32  */
+  
+    // int32
     template<int32_t do_func(int32_t, const libdivide_s32_t*),
              MAYBE_VECTOR_PARAM(libdivide_s32_t)>
     struct denom_s32 {
@@ -1788,8 +1868,7 @@ namespace libdivide_internal {
     template<> struct algo_s32<ALGORITHM4> { typedef denom_s32<libdivide_s32_do_alg4, MAYBE_VECTOR(libdivide_s32_do_vector_alg4)>::divider divider; };
     template<> struct algo_s32<BRANCHFREE> { typedef base<int32_t, libdivide_s32_branchfree_t, libdivide_s32_branchfree_gen, libdivide_s32_branchfree_do, MAYBE_VECTOR(libdivide_s32_branchfree_do_vector)> divider; };
     
-    
-    /* int64 */
+    // int64
     template<int64_t do_func(int64_t, const libdivide_s64_t*),
              MAYBE_VECTOR_PARAM(libdivide_s64_t)>
     struct denom_s64 {
@@ -1804,20 +1883,20 @@ namespace libdivide_internal {
     template<> struct algo_s64<ALGORITHM4> { typedef denom_s64<libdivide_s64_do_alg4, MAYBE_VECTOR(libdivide_s64_do_vector_alg4)>::divider divider; };
     template<> struct algo_s64<BRANCHFREE> { typedef base<int64_t, libdivide_s64_branchfree_t, libdivide_s64_branchfree_gen, libdivide_s64_branchfree_do, MAYBE_VECTOR(libdivide_s64_branchfree_do_vector)> divider; };
     
-    /* Bogus versions to allow templated code to operate on int and uint uniformly */
+    // Bogus versions to allow templated code to operate on int and uint uniformly
     template<> struct algo_u32<ALGORITHM3>  { typedef denom_u32<crash_u32, MAYBE_VECTOR(crash_u32_vector)>::divider divider; };
     template<> struct algo_u32<ALGORITHM4>  { typedef denom_u32<crash_u32, MAYBE_VECTOR(crash_u32_vector)>::divider divider; };
     template<> struct algo_u64<ALGORITHM3>  { typedef denom_u64<crash_u64, MAYBE_VECTOR(crash_u64_vector)>::divider divider; };
     template<> struct algo_u64<ALGORITHM4>  { typedef denom_u64<crash_u64, MAYBE_VECTOR(crash_u64_vector)>::divider divider; };
     
-    /* Templated dispatch using partial specialization */
+    // Templated dispatch using partial specialization
     template<typename T, int ALGO> struct dispatcher{};
     template<int ALGO> struct dispatcher<uint32_t, ALGO> { typedef struct algo_u32<ALGO> algo; };
     template<int ALGO> struct dispatcher<int32_t, ALGO>  { typedef struct algo_s32<ALGO> algo; };
     template<int ALGO> struct dispatcher<uint64_t, ALGO> { typedef struct algo_u64<ALGO> algo; };
     template<int ALGO> struct dispatcher<int64_t, ALGO>  { typedef struct algo_s64<ALGO> algo; };
     
-    /* Overloads that don't depend on the algorithm. */
+    // Overloads that don't depend on the algorithm.
     inline uint32_t recover(const libdivide_u32_t *s) { return libdivide_u32_recover(s); }
     inline int32_t  recover(const libdivide_s32_t *s) { return libdivide_s32_recover(s); }
     inline uint64_t recover(const libdivide_u64_t *s) { return libdivide_u64_recover(s); }
@@ -1833,7 +1912,7 @@ namespace libdivide_internal {
     inline int get_algorithm(const libdivide_u64_t *s) { return libdivide_u64_get_algorithm(s); }
     inline int get_algorithm(const libdivide_s64_t *s) { return libdivide_s64_get_algorithm(s); }
     
-    /* Fallback for branchfree variants, which do not support unswitching */
+    // Fallback for branchfree variants, which do not support unswitching
     template<typename T> int get_algorithm(const T *) { return -1; }
 }
 
@@ -1841,67 +1920,71 @@ template<typename T, int ALGO = BRANCHFULL>
 class divider
 {
     private:
-    /* Here's the actual divider */
+    // Here's the actual divider 
     typedef typename libdivide_internal::dispatcher<T, ALGO>::algo::divider div_t;
     div_t sub;
     
-    /* unswitch() friend declaration */
+    // unswitch() friend declaration 
     template<int NEW_ALGO, typename S> friend divider<S, NEW_ALGO> unswitch(const divider<S, BRANCHFULL> & d);
     
-    /* Constructor used by the unswitch friend */
+    // Constructor used by the unswitch friend 
     divider(const div_t &denom) : sub(denom) { }
     
     public:
     
-    /* Ordinary constructor, that takes the divisor as a parameter. */
+    // Ordinary constructor, that takes the divisor as a parameter. 
     divider(T n) : sub(n) { }
     
-    /* Default constructor. We leave this deliberately undefined so that creating an array of divider and then initializing them doesn't slow us down. */
+    // Default constructor. We leave this deliberately undefined so that
+    // creating an array of divider and then initializing them doesn't slow us
+    // down.
     divider() { }
     
-    /* Divides the parameter by the divisor, returning the quotient */
+    // Divides the parameter by the divisor, returning the quotient 
     T perform_divide(T val) const { return sub.perform_divide(val); }
     
-    /* Recovers the divisor that was used to initialize the divider */
+    // Recovers the divisor that was used to initialize the divider 
     T recover_divisor() const { return libdivide_internal::recover(&sub.denom); }
     
 #if LIBDIVIDE_USE_SSE2
-    /* Treats the vector as either two or four packed values (depending on the size), and divides each of them by the divisor, returning the packed quotients. */
+    // Treats the vector as either two or four packed values (depending on the
+    // size), and divides each of them by the divisor, returning the packed
+    // quotients.
     __m128i perform_divide_vector(__m128i val) const { return sub.perform_divide_vector(val); } 
 #endif
 
-    /* Returns the index of algorithm, for use in the unswitch function. Does not apply to branchfree variant. */
+    // Returns the index of algorithm, for use in the unswitch function. Does
+    // not apply to branchfree variant.
     int get_algorithm() const { return libdivide_internal::get_algorithm(&sub.denom); } // returns the algorithm for unswitching
     
-    /* operator== */
+    // operator== 
     bool operator==(const divider<T, ALGO> & him) const { return sub.denom.magic == him.sub.denom.magic && sub.denom.more == him.sub.denom.more; }
     bool operator!=(const divider<T, ALGO> & him) const { return ! (*this == him); }
 };
 
-/* Returns a divider specialized for the given algorithm. */
+// Returns a divider specialized for the given algorithm. 
 template<int NEW_ALGO, typename T>
 divider<T, NEW_ALGO> unswitch(const divider<T, BRANCHFULL> & d) { return divider<T, NEW_ALGO>(d.sub.denom); }
 
 
-/* Overload of the / operator for scalar division. */
+// Overload of the / operator for scalar division. 
 template<typename int_type, int ALGO>
 int_type operator/(int_type numer, const divider<int_type, ALGO> & denom) {
     return denom.perform_divide(numer);
 }
 
 #if  LIBDIVIDE_USE_SSE2
-/* Overload of the / operator for vector division. */
+// Overload of the / operator for vector division. 
 template<typename int_type, int ALGO>
 __m128i operator/(__m128i numer, const divider<int_type, ALGO> & denom) {
     return denom.perform_divide_vector(numer);
 }
 #endif
- 
- 
+
 #endif //__cplusplus
     
-#endif //LIBDIVIDE_HEADER_ONLY
+#endif // LIBDIVIDE_HEADER_ONLY
 #ifdef __cplusplus
-LIBDIVIDE_CLOSE_BRACKET //close namespace libdivide
-LIBDIVIDE_CLOSE_BRACKET //close anonymous namespace
+LIBDIVIDE_CLOSE_BRACKET // close namespace libdivide
+LIBDIVIDE_CLOSE_BRACKET // close anonymous namespace
 #endif

--- a/libdivide.h
+++ b/libdivide.h
@@ -1004,7 +1004,7 @@ static inline struct libdivide_u64_t libdivide_internal_u64_gen(uint64_t d, int 
             const uint64_t twice_rem = rem + rem;
             if (twice_rem >= d || twice_rem < rem) proposed_m += 1;
                 more = floor_log_2_d | LIBDIVIDE_ADD_MARKER;
-                }
+        }
         result.magic = 1 + proposed_m;
         result.more = more;
         // result.more's shift should in general be ceil_log_2_d. But if we
@@ -1970,7 +1970,6 @@ class divider
 template<int NEW_ALGO, typename T>
 divider<T, NEW_ALGO> unswitch(const divider<T, BRANCHFULL> & d) { return divider<T, NEW_ALGO>(d.sub.denom); }
 
-
 // Overload of the / operator for scalar division. 
 template<typename int_type, int ALGO>
 int_type operator/(int_type numer, const divider<int_type, ALGO> & denom) {
@@ -1988,6 +1987,7 @@ __m128i operator/(__m128i numer, const divider<int_type, ALGO> & denom) {
 #endif //__cplusplus
     
 #endif // LIBDIVIDE_HEADER_ONLY
+
 #ifdef __cplusplus
 LIBDIVIDE_CLOSE_BRACKET // close namespace libdivide
 LIBDIVIDE_CLOSE_BRACKET // close anonymous namespace

--- a/libdivide.h
+++ b/libdivide.h
@@ -472,7 +472,8 @@ static inline int32_t libdivide__count_trailing_zeros32(uint32_t val) {
 #else
     // Dorky way to count trailing zeros. Note that this hangs for val = 0!
     int32_t result = 0;
-    val = (val ^ (val - 1)) >> 1; // Set v's trailing 0s to 1s and zero rest
+    // Set v's trailing 0s to 1s and zero rest
+    val = (val ^ (val - 1)) >> 1;
     while (val) {
         val >>= 1;
         result++;
@@ -789,7 +790,8 @@ static inline struct libdivide_u32_t libdivide_internal_u32_gen(uint32_t d, int 
             // (2**power) / d. However, we already have (2**(power-1))/d and
             // its remainder.  By doubling both, and then correcting the
             // remainder, we can compute the larger division.
-            proposed_m += proposed_m; // don't care about overflow here - in fact, we expect it
+            // don't care about overflow here - in fact, we expect it
+            proposed_m += proposed_m;
             const uint32_t twice_rem = rem + rem;
             if (twice_rem >= d || twice_rem < rem) proposed_m += 1;
             more = floor_log_2_d | LIBDIVIDE_ADD_MARKER;
@@ -977,7 +979,7 @@ static inline struct libdivide_u64_t libdivide_internal_u64_gen(uint64_t d, int 
     } else {
         uint64_t proposed_m, rem;
         uint8_t more;
-        proposed_m = libdivide_128_div_64_to_64(1ULL << floor_log_2_d, 0, d, &rem); //== (1 << (64 + floor_log_2_d)) / d
+        proposed_m = libdivide_128_div_64_to_64(1ULL << floor_log_2_d, 0, d, &rem); // == (1 << (64 + floor_log_2_d)) / d
         
         LIBDIVIDE_ASSERT(rem > 0 && rem < d);
         const uint64_t e = d - rem;
@@ -991,7 +993,8 @@ static inline struct libdivide_u64_t libdivide_internal_u64_gen(uint64_t d, int 
             // (2**power) / d. However, we already have (2**(power-1))/d and
             // its remainder. By doubling both, and then correcting the
             // remainder, we can compute the larger division.
-            proposed_m += proposed_m; // don't care about overflow here - in fact, we expect it
+            // don't care about overflow here - in fact, we expect it
+            proposed_m += proposed_m;
             const uint64_t twice_rem = rem + rem;
             if (twice_rem >= d || twice_rem < rem) proposed_m += 1;
                 more = floor_log_2_d | LIBDIVIDE_ADD_MARKER;
@@ -1188,7 +1191,9 @@ static inline struct libdivide_s32_t libdivide_internal_s32_gen(int32_t d, int b
     uint32_t ud = (uint32_t)d;
     uint32_t absD = (d < 0 ? -ud : ud); // gcc optimizes this to the fast abs trick
     const uint32_t floor_log_2_d = 31 - libdivide__count_leading_zeros32(absD);
-    if ((absD & (absD - 1)) == 0) { // check if exactly one bit is set, don't care if absD is 0 since that's divide by zero
+    // check if exactly one bit is set,
+    // don't care if absD is 0 since that's divide by zero
+    if ((absD & (absD - 1)) == 0) {
         // Branchfree and normal paths are exactly the same
         result.magic = 0;
         result.more = floor_log_2_d | (d < 0 ? LIBDIVIDE_NEGATIVE_DIVISOR : 0) | LIBDIVIDE_S32_SHIFT_PATH;
@@ -1477,7 +1482,9 @@ static inline struct libdivide_s64_t libdivide_internal_s64_gen(int64_t d, int b
     const uint64_t ud = (uint64_t)d;
     const uint64_t absD = (d < 0 ? -ud : ud); // gcc optimizes this to the fast abs trick
     const uint32_t floor_log_2_d = 63 - libdivide__count_leading_zeros64(absD);
-    if ((absD & (absD - 1)) == 0) { // check if exactly one bit is set, don't care if absD is 0 since that's divide by zero
+    // check if exactly one bit is set,
+    // don't care if absD is 0 since that's divide by zero
+    if ((absD & (absD - 1)) == 0) {
         // Branchfree and non-branchfree cases are the same
         result.magic = 0;
         result.more = floor_log_2_d | (d < 0 ? LIBDIVIDE_NEGATIVE_DIVISOR : 0);

--- a/libdivide.h
+++ b/libdivide.h
@@ -605,9 +605,10 @@ static uint64_t libdivide_128_div_64_to_64(uint64_t u1, uint64_t u0, uint64_t v,
     
     if (u1 >= v) {                  // If overflow, set rem.
         if (r != NULL)              // to an impossible value,
-            *r = (uint64_t)(-1);    // and return the largest
-        return (uint64_t)(-1);}     // possible quotient.
-    
+            *r = (uint64_t) -1;    // and return the largest
+        return (uint64_t) -1;      // possible quotient.
+    }
+
     // count leading zeros
     s = libdivide__count_leading_zeros64(v); // 0 <= s <= 63.
     if (s > 0) {
@@ -625,25 +626,27 @@ static uint64_t libdivide_128_div_64_to_64(uint64_t u1, uint64_t u0, uint64_t v,
 
     un1 = un10 >> 32;         // Break right half of
     un0 = un10 & 0xFFFFFFFF;  // dividend into two digits.
-    
+
     q1 = un64/vn1;            // Compute the first
     rhat = un64 - q1*vn1;     // quotient digit, q1.
 again1:
     if (q1 >= b || q1*vn0 > b*rhat + un1) {
         q1 = q1 - 1;
         rhat = rhat + vn1;
-        if (rhat < b) goto again1;}
-    
+        if (rhat < b) goto again1;
+    }
+
     un21 = un64*b + un1 - q1*v;  // Multiply and subtract.
-    
+
     q0 = un21/vn1;            // Compute the second
     rhat = un21 - q0*vn1;     // quotient digit, q0.
 again2:
     if (q0 >= b || q0*vn0 > b*rhat + un0) {
         q0 = q0 - 1;
         rhat = rhat + vn1;
-        if (rhat < b) goto again2;}
-    
+        if (rhat < b) goto again2;
+    }
+
     if (r != NULL)                          // If remainder is wanted,
         *r = (un21*b + un0 - q0*v) >> s;    // return it.
     return q1*b + q0;

--- a/libdivide.h
+++ b/libdivide.h
@@ -1753,9 +1753,9 @@ namespace libdivide_internal {
     };
     template<int ALGO> struct algo_u32 { };
     template<> struct algo_u32<BRANCHFULL> { typedef denom_u32<libdivide_u32_do, MAYBE_VECTOR(libdivide_u32_do_vector)>::divider divider; };
-    template<> struct algo_u32<ALGORITHM0>  { typedef denom_u32<libdivide_u32_do_alg0, MAYBE_VECTOR(libdivide_u32_do_vector_alg0)>::divider divider; };
-    template<> struct algo_u32<ALGORITHM1>  { typedef denom_u32<libdivide_u32_do_alg1, MAYBE_VECTOR(libdivide_u32_do_vector_alg1)>::divider divider; };
-    template<> struct algo_u32<ALGORITHM2>  { typedef denom_u32<libdivide_u32_do_alg2, MAYBE_VECTOR(libdivide_u32_do_vector_alg2)>::divider divider; };
+    template<> struct algo_u32<ALGORITHM0> { typedef denom_u32<libdivide_u32_do_alg0, MAYBE_VECTOR(libdivide_u32_do_vector_alg0)>::divider divider; };
+    template<> struct algo_u32<ALGORITHM1> { typedef denom_u32<libdivide_u32_do_alg1, MAYBE_VECTOR(libdivide_u32_do_vector_alg1)>::divider divider; };
+    template<> struct algo_u32<ALGORITHM2> { typedef denom_u32<libdivide_u32_do_alg2, MAYBE_VECTOR(libdivide_u32_do_vector_alg2)>::divider divider; };
     template<> struct algo_u32<BRANCHFREE> { typedef base<uint32_t, libdivide_u32_branchfree_t, libdivide_u32_branchfree_gen, libdivide_u32_branchfree_do, MAYBE_VECTOR(libdivide_u32_branchfree_do_vector)> divider;  };
     
     /* uint64 */
@@ -1767,9 +1767,9 @@ namespace libdivide_internal {
     };
     template<int ALGO> struct algo_u64 { };
     template<> struct algo_u64<BRANCHFULL> { typedef denom_u64<libdivide_u64_do, MAYBE_VECTOR(libdivide_u64_do_vector)>::divider divider; };
-    template<> struct algo_u64<ALGORITHM0>  { typedef denom_u64<libdivide_u64_do_alg0, MAYBE_VECTOR(libdivide_u64_do_vector_alg0)>::divider divider; };
-    template<> struct algo_u64<ALGORITHM1>  { typedef denom_u64<libdivide_u64_do_alg1, MAYBE_VECTOR(libdivide_u64_do_vector_alg1)>::divider divider; };
-    template<> struct algo_u64<ALGORITHM2>  { typedef denom_u64<libdivide_u64_do_alg2, MAYBE_VECTOR(libdivide_u64_do_vector_alg2)>::divider divider; };
+    template<> struct algo_u64<ALGORITHM0> { typedef denom_u64<libdivide_u64_do_alg0, MAYBE_VECTOR(libdivide_u64_do_vector_alg0)>::divider divider; };
+    template<> struct algo_u64<ALGORITHM1> { typedef denom_u64<libdivide_u64_do_alg1, MAYBE_VECTOR(libdivide_u64_do_vector_alg1)>::divider divider; };
+    template<> struct algo_u64<ALGORITHM2> { typedef denom_u64<libdivide_u64_do_alg2, MAYBE_VECTOR(libdivide_u64_do_vector_alg2)>::divider divider; };
     template<> struct algo_u64<BRANCHFREE> { typedef base<uint64_t, libdivide_u64_branchfree_t, libdivide_u64_branchfree_gen, libdivide_u64_branchfree_do, MAYBE_VECTOR(libdivide_u64_branchfree_do_vector)> divider;  };
     
 
@@ -1781,11 +1781,11 @@ namespace libdivide_internal {
     };
     template<int ALGO> struct algo_s32 { };
     template<> struct algo_s32<BRANCHFULL> { typedef denom_s32<libdivide_s32_do, MAYBE_VECTOR(libdivide_s32_do_vector)>::divider divider; };
-    template<> struct algo_s32<ALGORITHM0>  { typedef denom_s32<libdivide_s32_do_alg0, MAYBE_VECTOR(libdivide_s32_do_vector_alg0)>::divider divider; };
-    template<> struct algo_s32<ALGORITHM1>  { typedef denom_s32<libdivide_s32_do_alg1, MAYBE_VECTOR(libdivide_s32_do_vector_alg1)>::divider divider; };
-    template<> struct algo_s32<ALGORITHM2>  { typedef denom_s32<libdivide_s32_do_alg2, MAYBE_VECTOR(libdivide_s32_do_vector_alg2)>::divider divider; };
-    template<> struct algo_s32<ALGORITHM3>  { typedef denom_s32<libdivide_s32_do_alg3, MAYBE_VECTOR(libdivide_s32_do_vector_alg3)>::divider divider; };
-    template<> struct algo_s32<ALGORITHM4>  { typedef denom_s32<libdivide_s32_do_alg4, MAYBE_VECTOR(libdivide_s32_do_vector_alg4)>::divider divider; };
+    template<> struct algo_s32<ALGORITHM0> { typedef denom_s32<libdivide_s32_do_alg0, MAYBE_VECTOR(libdivide_s32_do_vector_alg0)>::divider divider; };
+    template<> struct algo_s32<ALGORITHM1> { typedef denom_s32<libdivide_s32_do_alg1, MAYBE_VECTOR(libdivide_s32_do_vector_alg1)>::divider divider; };
+    template<> struct algo_s32<ALGORITHM2> { typedef denom_s32<libdivide_s32_do_alg2, MAYBE_VECTOR(libdivide_s32_do_vector_alg2)>::divider divider; };
+    template<> struct algo_s32<ALGORITHM3> { typedef denom_s32<libdivide_s32_do_alg3, MAYBE_VECTOR(libdivide_s32_do_vector_alg3)>::divider divider; };
+    template<> struct algo_s32<ALGORITHM4> { typedef denom_s32<libdivide_s32_do_alg4, MAYBE_VECTOR(libdivide_s32_do_vector_alg4)>::divider divider; };
     template<> struct algo_s32<BRANCHFREE> { typedef base<int32_t, libdivide_s32_branchfree_t, libdivide_s32_branchfree_gen, libdivide_s32_branchfree_do, MAYBE_VECTOR(libdivide_s32_branchfree_do_vector)> divider; };
     
     
@@ -1797,11 +1797,11 @@ namespace libdivide_internal {
     };
     template<int ALGO> struct algo_s64 { };
     template<> struct algo_s64<BRANCHFULL> { typedef denom_s64<libdivide_s64_do, MAYBE_VECTOR(libdivide_s64_do_vector)>::divider divider; };
-    template<> struct algo_s64<ALGORITHM0>  { typedef denom_s64<libdivide_s64_do_alg0, MAYBE_VECTOR(libdivide_s64_do_vector_alg0)>::divider divider; };
-    template<> struct algo_s64<ALGORITHM1>  { typedef denom_s64<libdivide_s64_do_alg1, MAYBE_VECTOR(libdivide_s64_do_vector_alg1)>::divider divider; };
-    template<> struct algo_s64<ALGORITHM2>  { typedef denom_s64<libdivide_s64_do_alg2, MAYBE_VECTOR(libdivide_s64_do_vector_alg2)>::divider divider; };
-    template<> struct algo_s64<ALGORITHM3>  { typedef denom_s64<libdivide_s64_do_alg3, MAYBE_VECTOR(libdivide_s64_do_vector_alg3)>::divider divider; };
-    template<> struct algo_s64<ALGORITHM4>  { typedef denom_s64<libdivide_s64_do_alg4, MAYBE_VECTOR(libdivide_s64_do_vector_alg4)>::divider divider; };
+    template<> struct algo_s64<ALGORITHM0> { typedef denom_s64<libdivide_s64_do_alg0, MAYBE_VECTOR(libdivide_s64_do_vector_alg0)>::divider divider; };
+    template<> struct algo_s64<ALGORITHM1> { typedef denom_s64<libdivide_s64_do_alg1, MAYBE_VECTOR(libdivide_s64_do_vector_alg1)>::divider divider; };
+    template<> struct algo_s64<ALGORITHM2> { typedef denom_s64<libdivide_s64_do_alg2, MAYBE_VECTOR(libdivide_s64_do_vector_alg2)>::divider divider; };
+    template<> struct algo_s64<ALGORITHM3> { typedef denom_s64<libdivide_s64_do_alg3, MAYBE_VECTOR(libdivide_s64_do_vector_alg3)>::divider divider; };
+    template<> struct algo_s64<ALGORITHM4> { typedef denom_s64<libdivide_s64_do_alg4, MAYBE_VECTOR(libdivide_s64_do_vector_alg4)>::divider divider; };
     template<> struct algo_s64<BRANCHFREE> { typedef base<int64_t, libdivide_s64_branchfree_t, libdivide_s64_branchfree_gen, libdivide_s64_branchfree_do, MAYBE_VECTOR(libdivide_s64_branchfree_do_vector)> divider; };
     
     /* Bogus versions to allow templated code to operate on int and uint uniformly */
@@ -1813,9 +1813,9 @@ namespace libdivide_internal {
     /* Templated dispatch using partial specialization */
     template<typename T, int ALGO> struct dispatcher{};
     template<int ALGO> struct dispatcher<uint32_t, ALGO> { typedef struct algo_u32<ALGO> algo; };
-    template<int ALGO> struct dispatcher<int32_t, ALGO> { typedef struct algo_s32<ALGO> algo; };
+    template<int ALGO> struct dispatcher<int32_t, ALGO>  { typedef struct algo_s32<ALGO> algo; };
     template<int ALGO> struct dispatcher<uint64_t, ALGO> { typedef struct algo_u64<ALGO> algo; };
-    template<int ALGO> struct dispatcher<int64_t, ALGO> { typedef struct algo_s64<ALGO> algo; };
+    template<int ALGO> struct dispatcher<int64_t, ALGO>  { typedef struct algo_s64<ALGO> algo; };
     
     /* Overloads that don't depend on the algorithm. */
     inline uint32_t recover(const libdivide_u32_t *s) { return libdivide_u32_recover(s); }

--- a/libdivide.h
+++ b/libdivide.h
@@ -770,7 +770,7 @@ struct libdivide_u32_t libdivide_u32_gen(uint32_t d) {
 }
     
 struct libdivide_u32_branchfree_t libdivide_u32_branchfree_gen(uint32_t d) {
-    struct libdivide_u32_t tmp = libdivide_internal_u32_gen(d, 1);)
+    struct libdivide_u32_t tmp = libdivide_internal_u32_gen(d, 1);
     struct libdivide_u32_branchfree_t ret = {tmp.magic, (uint8_t)(tmp.more & LIBDIVIDE_32_SHIFT_MASK)};
     return ret;
 }

--- a/libdivide.h
+++ b/libdivide.h
@@ -63,7 +63,13 @@ typedef unsigned __int8 uint8_t;
 #endif
 
 #if LIBDIVIDE_ASSERTIONS_ON
-#define LIBDIVIDE_ASSERT(x) do { if (! (x)) { fprintf(stderr, "Assertion failure on line %ld: %s\n", (long)__LINE__, #x); exit(-1); } } while (0)
+#define LIBDIVIDE_ASSERT(x) \
+    do { \
+        if (! (x)) { \
+            fprintf(stderr, "Assertion failure on line %ld: %s\n", (long)__LINE__, #x); \
+            exit(-1); \
+        } \
+    } while (0)
 #else
 #define LIBDIVIDE_ASSERT(x)
 #endif
@@ -386,7 +392,7 @@ static inline __m128i libdivide_s64_shift_right_vector(__m128i v, int amt) {
     const int b = 64 - amt;
     __m128i m = libdivide__u64_to_m128(1ULL << (b - 1));
     __m128i x = _mm_srl_epi64(v, libdivide_u32_to_m128i(amt));
-    __m128i result = _mm_sub_epi64(_mm_xor_si128(x, m), m); //result = x^m - m
+    __m128i result = _mm_sub_epi64(_mm_xor_si128(x, m), m); // result = x^m - m
     return result;
 }
 

--- a/libdivide.h
+++ b/libdivide.h
@@ -864,8 +864,8 @@ uint32_t libdivide_u32_recover(const struct libdivide_u32_t *denom) {
         // overflow. So we have to compute it as 2^(32+shift)/(m+2^32), and
         // then double the quotient and remainder.
         // TODO: do something better than 64 bit math
-        uint64_t half_n = 1LLU << (32 + shift);
-        uint64_t d = (1LLU << 32) | denom->magic;
+        uint64_t half_n = 1ULL << (32 + shift);
+        uint64_t d = (1ULL << 32) | denom->magic;
         // Note that the quotient is guaranteed <= 32 bits, but the remainder
         // may need 33!
         uint32_t half_q = (uint32_t)(half_n / d);
@@ -1060,7 +1060,7 @@ uint64_t libdivide_u64_recover(const struct libdivide_u64_t *denom) {
         // We need to ceil it.
         // We know d is not a power of 2, so m is not a power of 2,
         // so we can just add 1 to the floor
-        uint64_t hi_dividend = 1LLU << shift;
+        uint64_t hi_dividend = 1ULL << shift;
         uint64_t rem_ignored;
         return 1 + libdivide_128_div_64_to_64(hi_dividend, 0, denom->magic, &rem_ignored);
     } else {
@@ -1074,13 +1074,13 @@ uint64_t libdivide_u64_recover(const struct libdivide_u64_t *denom) {
         // However we can optimize that easily
         if (denom->magic == 0) {
             // 2^(64 + shift + 1) / (2^64) == 2^(shift + 1)
-            return 1LLU << (shift + 1);
+            return 1ULL << (shift + 1);
         }
         
         // Full n is a (potentially) 129 bit value
         // half_n is a 128 bit value
         // Compute the hi half of half_n. Low half is 0.
-        uint64_t half_n_hi = 1LLU << shift, half_n_lo = 0;
+        uint64_t half_n_hi = 1ULL << shift, half_n_lo = 0;
         // d is a 65 bit value. The high bit is always set to 1.
         const uint64_t d_hi = 1, d_lo = denom->magic;
         // Note that the quotient is guaranteed <= 64 bits,
@@ -1337,7 +1337,7 @@ int32_t libdivide_s32_recover(const struct libdivide_s32_t *denom) {
         }
         
         uint32_t d = (uint32_t)(magic_was_negated ? -denom->magic : denom->magic);
-        uint64_t n = 1LLU << (32 + shift); // Note that the shift cannot exceed 30
+        uint64_t n = 1ULL << (32 + shift); // Note that the shift cannot exceed 30
         uint32_t q = (uint32_t)(n / d);
         int32_t result = (int32_t)q;
         result += 1;
@@ -1592,7 +1592,7 @@ int64_t libdivide_s64_branchfree_do(int64_t numer, const struct libdivide_s64_br
     // 2, or (2**shift) if it is not a power of 2.
     uint32_t is_power_of_2 = (magic == 0);
     uint64_t q_sign = (uint64_t)(q >> 63);
-    q += q_sign & ((1LLU << shift) - is_power_of_2);
+    q += q_sign & ((1ULL << shift) - is_power_of_2);
     
     // Arithmetic right shift
     q >>= shift;
@@ -1606,7 +1606,7 @@ int64_t libdivide_s64_recover(const struct libdivide_s64_t *denom) {
     uint8_t more = denom->more;
     uint8_t shift = more & LIBDIVIDE_64_SHIFT_MASK;
     if (denom->magic == 0) { // shift path
-        uint64_t absD = 1LLU << shift;
+        uint64_t absD = 1ULL << shift;
         if (more & LIBDIVIDE_NEGATIVE_DIVISOR) {
             absD *= -1;
         }
@@ -1617,7 +1617,7 @@ int64_t libdivide_s64_recover(const struct libdivide_s64_t *denom) {
         int magic_was_negated = (more & LIBDIVIDE_ADD_MARKER) ? denom->magic > 0 : denom->magic < 0;
 
         uint64_t d = (uint64_t)(magic_was_negated ? -denom->magic : denom->magic);
-        uint64_t n_hi = 1LLU << shift, n_lo = 0;
+        uint64_t n_hi = 1ULL << shift, n_lo = 0;
         uint64_t rem_ignored;
         uint64_t q = libdivide_128_div_64_to_64(n_hi, n_lo, d, &rem_ignored);
         int64_t result = (int64_t)(q + 1);

--- a/libdivide.h
+++ b/libdivide.h
@@ -1741,7 +1741,6 @@ __m128i libdivide_s64_do_vector_alg4(__m128i numers, const struct libdivide_s64_
 }
 
 __m128i libdivide_s64_branchfree_do_vector(__m128i numers, const struct libdivide_s64_branchfree_t * denom) {
-    
     int64_t magic = denom->magic;
     uint8_t more = denom->more;
     uint8_t shift = more & LIBDIVIDE_64_SHIFT_MASK;

--- a/libdivide.h
+++ b/libdivide.h
@@ -70,8 +70,8 @@ typedef unsigned __int8 uint8_t;
 
 // libdivide may use the pmuldq (vector signed 32x32->64 mult instruction)
 // which is in SSE 4.1. However, signed multiplication can be emulated
-// efficiently with unsigned multiplication, and SSE 4.1 is currently rare,
-// so it is OK to not turn this on.
+// efficiently with unsigned multiplication, and SSE 4.1 is currently rare, so
+// it is OK to not turn this on.
 #ifdef LIBDIVIDE_USE_SSE4_1
 #include <smmintrin.h>
 #endif
@@ -89,10 +89,10 @@ namespace LIBDIVIDE_OPEN_BRACKET
 namespace libdivide LIBDIVIDE_OPEN_BRACKET
 #endif
 
-// Explanation of "more" field: bit 6 is whether to use shift path.  If we are
+// Explanation of "more" field: bit 6 is whether to use shift path. If we are
 // using the shift path, bit 7 is whether the divisor is negative in the signed
-// case; in the unsigned case it is 0.   Bits 0-4 is shift value (for shift
-// path or mult path).  In 32 bit case, bit 5 is always 0.  We use bit 7 as the
+// case; in the unsigned case it is 0. Bits 0-4 is shift value (for shift
+// path or mult path).  In 32 bit case, bit 5 is always 0. We use bit 7 as the
 // "negative divisor indicator" so that we can use sign extension to
 // efficiently go to a full-width -1.
 //
@@ -363,10 +363,10 @@ static inline __m128i libdivide_get_00000000FFFFFFFF(void) {
 }
 
 static inline __m128i libdivide_s64_signbits(__m128i v) {
-    // we want to compute v >> 63, that is, _mm_srai_epi64(v, 63).  But there
-    // is no 64 bit shift right arithmetic instruction in SSE2.  So we have to
+    // we want to compute v >> 63, that is, _mm_srai_epi64(v, 63). But there
+    // is no 64 bit shift right arithmetic instruction in SSE2. So we have to
     // fake it by first duplicating the high 32 bit values, and then using a 32
-    // bit shift.  Another option would be to use _mm_srli_epi64(v, 63) and
+    // bit shift. Another option would be to use _mm_srli_epi64(v, 63) and
     // then subtract that from 0, but that approach appears to be substantially
     // slower for unknown reasons
     __m128i hiBitsDuped = _mm_shuffle_epi32(v, _MM_SHUFFLE(3, 3, 1, 1));
@@ -446,7 +446,7 @@ static inline __m128i libdivide_mullhi_s32_flat_vector(__m128i a, __m128i b) {
 #else
 
 // SSE2 does not have a signed multiplication instruction, but we can convert
-// unsigned to signed pretty efficiently.  Again, b is just a 32 bit value
+// unsigned to signed pretty efficiently. Again, b is just a 32 bit value
 // repeated four times.
 static inline __m128i libdivide_mullhi_s32_flat_vector(__m128i a, __m128i b) {
     __m128i p = libdivide__mullhi_u32_flat_vector(a, b);
@@ -547,8 +547,8 @@ static inline int32_t libdivide__count_leading_zeros64(uint64_t val) {
 }
 
 // libdivide_64_div_32_to_32: divides a 64 bit uint {u1, u0} by a 32 bit
-// uint {v}. The result must fit in 32 bits. Returns the quotient directly and
-// the remainder in *r
+// uint {v}. The result must fit in 32 bits.
+// Returns the quotient directly and the remainder in *r
 #if (LIBDIVIDE_IS_i386 || LIBDIVIDE_IS_X86_64) && LIBDIVIDE_GCC_STYLE_ASM
 static uint32_t libdivide_64_div_32_to_32(uint32_t u1, uint32_t u0, uint32_t v, uint32_t *r) {
     uint32_t result;
@@ -589,24 +589,24 @@ static uint64_t libdivide_128_div_64_to_64(uint64_t u1, uint64_t u0, uint64_t v,
 
 static uint64_t libdivide_128_div_64_to_64(uint64_t u1, uint64_t u0, uint64_t v, uint64_t *r) {    
     const uint64_t b = (1ULL << 32); // Number base (16 bits).
-    uint64_t un1, un0,        // Norm. dividend LSD's.
-    vn1, vn0,        // Norm. divisor digits.
-    q1, q0,          // Quotient digits.
-    un64, un21, un10,// Dividend digit pairs.
-    rhat;            // A remainder.
-    int s;                  // Shift amount for norm.
+    uint64_t un1, un0,  // Norm. dividend LSD's.
+    vn1, vn0,           // Norm. divisor digits.
+    q1, q0,             // Quotient digits.
+    un64, un21, un10,   // Dividend digit pairs.
+    rhat;               // A remainder.
+    int s;              // Shift amount for norm.
     
-    if (u1 >= v) {            // If overflow, set rem.
-        if (r != NULL)         // to an impossible value,
+    if (u1 >= v) {                  // If overflow, set rem.
+        if (r != NULL)              // to an impossible value,
             *r = (uint64_t)(-1);    // and return the largest
-        return (uint64_t)(-1);}    // possible quotient.
+        return (uint64_t)(-1);}     // possible quotient.
     
     // count leading zeros
     s = libdivide__count_leading_zeros64(v); // 0 <= s <= 63.
     if (s > 0) {
-        v = v << s;           // Normalize divisor.
+        v = v << s;         // Normalize divisor.
         un64 = (u1 << s) | ((u0 >> (64 - s)) & (-s >> 31));
-        un10 = u0 << s;       // Shift dividend left.
+        un10 = u0 << s;     // Shift dividend left.
     } else {
         // Avoid undefined behavior.
         un64 = u1 | u0;
@@ -637,8 +637,8 @@ again2:
         rhat = rhat + vn1;
         if (rhat < b) goto again2;}
     
-    if (r != NULL)            // If remainder is wanted,
-        *r = (un21*b + un0 - q0*v) >> s;     // return it.
+    if (r != NULL)                          // If remainder is wanted,
+        *r = (un21*b + un0 - q0*v) >> s;    // return it.
     return q1*b + q0;
 }
 #endif
@@ -796,7 +796,7 @@ static inline struct libdivide_u32_t libdivide_internal_u32_gen(uint32_t d, int 
         }
         result.magic = 1 + proposed_m;
         result.more = more;
-        // result.more's shift should in general be ceil_log_2_d.  But if we
+        // result.more's shift should in general be ceil_log_2_d. But if we
         // used the smaller power, we subtract one from the shift because we're
         // using the smaller power. If we're using the larger power, we
         // subtract one from the shift because it's taken care of by the add
@@ -989,7 +989,7 @@ static inline struct libdivide_u64_t libdivide_internal_u64_gen(uint64_t d, int 
         } else {
             // We have to use the general 65-bit algorithm.  We need to compute
             // (2**power) / d. However, we already have (2**(power-1))/d and
-            // its remainder.  By doubling both, and then correcting the
+            // its remainder. By doubling both, and then correcting the
             // remainder, we can compute the larger division.
             proposed_m += proposed_m; // don't care about overflow here - in fact, we expect it
             const uint64_t twice_rem = rem + rem;
@@ -998,7 +998,7 @@ static inline struct libdivide_u64_t libdivide_internal_u64_gen(uint64_t d, int 
                 }
         result.magic = 1 + proposed_m;
         result.more = more;
-        // result.more's shift should in general be ceil_log_2_d.  But if we
+        // result.more's shift should in general be ceil_log_2_d. But if we
         // used the smaller power, we subtract one from the shift because we're
         // using the smaller power. If we're using the larger power, we
         // subtract one from the shift because it's taken care of by the add
@@ -1182,7 +1182,7 @@ static inline struct libdivide_s32_t libdivide_internal_s32_gen(int32_t d, int b
     // If d is a power of 2, or negative a power of 2, we have to use a shift.
     // This is especially important because the magic algorithm fails for -1.
     // To check if d is a power of 2 or its inverse, it suffices to check
-    // whether its absolute value has exactly one bit set.  This works even for
+    // whether its absolute value has exactly one bit set. This works even for
     // INT_MIN, because abs(INT_MIN) == INT_MIN, and INT_MIN has one bit set
     // and is a power of 2.
     uint32_t ud = (uint32_t)d;
@@ -1302,12 +1302,7 @@ int32_t libdivide_s32_recover(const struct libdivide_s32_t *denom) {
     if (more & LIBDIVIDE_S32_SHIFT_PATH) {
         uint32_t absD = 1U << shift;
         if (more & LIBDIVIDE_NEGATIVE_DIVISOR) {
-#if LIBDIVIDE_VC
-#pragma warning( suppress : 4146 )
-            absD = -absD;
-#else
-            absD = -absD;
-#endif      
+            absD *= -1;
         }
         return (int32_t)absD;
     } else {
@@ -1315,8 +1310,8 @@ int32_t libdivide_s32_recover(const struct libdivide_s32_t *denom) {
         // We negate the magic number only in the branchfull case, and we don't
         // know which case we're in. However we have enough information to
         // determine the correct sign of the magic number. The divisor was
-        // negative if LIBDIVIDE_NEGATIVE_DIVISOR is set.  If ADD_MARKER is
-        // set, the magic number's sign is opposite that of the divisor.
+        // negative if LIBDIVIDE_NEGATIVE_DIVISOR is set. If ADD_MARKER is set,
+        // the magic number's sign is opposite that of the divisor.
         // We want to compute the positive magic number.
         int negative_divisor = (more & LIBDIVIDE_NEGATIVE_DIVISOR);
         int magic_was_negated = (more & LIBDIVIDE_ADD_MARKER) ? denom->magic > 0 : denom->magic < 0;
@@ -1597,12 +1592,7 @@ int64_t libdivide_s64_recover(const struct libdivide_s64_t *denom) {
     if (denom->magic == 0) { // shift path
         uint64_t absD = 1LLU << shift;
         if (more & LIBDIVIDE_NEGATIVE_DIVISOR) {
-#if LIBDIVIDE_VC
-#pragma warning( suppress : 4146 )
-            absD = -absD;
-#else
-            absD = -absD;
-#endif
+            absD *= -1;
         }
         return (int64_t)absD;
     } else {
@@ -1955,7 +1945,8 @@ class divider
 
     // Returns the index of algorithm, for use in the unswitch function. Does
     // not apply to branchfree variant.
-    int get_algorithm() const { return libdivide_internal::get_algorithm(&sub.denom); } // returns the algorithm for unswitching
+    // Returns the algorithm for unswitching.
+    int get_algorithm() const { return libdivide_internal::get_algorithm(&sub.denom); }
     
     // operator== 
     bool operator==(const divider<T, ALGO> & him) const { return sub.denom.magic == him.sub.denom.magic && sub.denom.more == him.sub.denom.more; }


### PR DESCRIPTION
Hi,

```libdivide.h``` is awesome but the code is a little messy. Most of the mess comes from the comments. So I have cleaned up the comments: all C-style comments ```/* */``` have been converted into ```//``` C++ comments. I have also inserted line breaks at column/character 80 for most comments.

I help improving the branchfree ```libdivide.h``` in the hope that you will merge it into the master branch soon.

P.S. I have not changed a single line of C/C++ code (only comments)

Best regards,
Kim