### PR TITLE
Hide SSE2 code behind #ifdefs

### DIFF
--- a/libdivide_test.cpp
+++ b/libdivide_test.cpp
@@ -121,7 +121,8 @@ private:
 		}
         test_unswitching(numer, denom, the_divider);
     }
-    
+
+#ifdef LIBDIVIDE_USE_SSE2
     template<int ALGO>
     void test_four(const T *numers, T denom, const divider<T, ALGO> & the_divider) {
 		const size_t count = 16 / sizeof(T);
@@ -145,6 +146,7 @@ private:
 			}
 		}
     }
+#endif
     
     template<int ALGO>
     void test_many(T denom) {
@@ -166,7 +168,9 @@ private:
             test_one(numers[1], denom, the_divider);
             test_one(numers[2], denom, the_divider);
             test_one(numers[3], denom, the_divider);
+#ifdef LIBDIVIDE_USE_SSE2
             test_four(numers, denom, the_divider);
+#endif
         }
         const T min = limits::min(), max = limits::max();
         const T wellKnownNumers[] = {0, max, max-1, max/2, max/2 - 1, min, min/2, min/4, 1, 2, 3, 4, 5, 6, 7, 8, 10, 36847, 50683, SHRT_MAX};


### PR DESCRIPTION
Make sure all code using SSE2 is guarded with `LIBDIVIDE_USE_SSE2` define.

As mentioned in #34, but this commit is independent from the build system.