### PR TITLE
Add CMake build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,14 @@ if(BUILD_TESTER)
     target_link_libraries(tester ${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
 endif(BUILD_TESTER)
 
+# benchmark
+option(BUILD_BENCHMARK "build benchmark executable" ON)
+if(BUILD_BENCHMARK)
+    add_executable(benchmark libdivide_benchmark.c)
+    target_link_libraries(benchmark ${PROJECT_NAME})
+    target_compile_definitions(benchmark PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif(BUILD_BENCHMARK)
+
 # CTest
 option(ENABLE_TESTING "enable testing with CTest" ON)
 if(ENABLE_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ include(CheckCXXCompilerFlag)
 include(CMakePushCheckState)
 
 cmake_push_check_state()
+set(CMAKE_REQUIRED_FLAGS -Werror)
 check_cxx_compiler_flag(-msse2 MSSE2_FLAG_AVAILABLE)
 cmake_pop_check_state()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,32 @@
 cmake_minimum_required(VERSION 3.1)
 project(libdivide)
 
+include(CheckCXXCompilerFlag)
+include(CMakePushCheckState)
+
+cmake_push_check_state()
+check_cxx_compiler_flag(-msse2 MSSE2_FLAG_AVAILABLE)
+cmake_pop_check_state()
+
+option(USE_SSE2 "use SSE2 instructions" ${MSSE2_FLAG_AVAILABLE})
+
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_compile_definitions(${PROJECT_NAME} INTERFACE $<$<CONFIG:Debug>:LIBDIVIDE_ASSERTIONS_ON=1>)
 target_compile_options(${PROJECT_NAME} INTERFACE
     $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-fstrict-aliasing -Wall -Wextra>
     )
+if(USE_SSE2)
+    message(STATUS "SSE2 is used")
+    target_compile_options(${PROJECT_NAME} INTERFACE
+        $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-msse2>
+        )
+    target_compile_definitions(${PROJECT_NAME} INTERFACE
+        LIBDIVIDE_USE_SSE2=1
+        )
+else(USE_SSE2)
+    message(STATUS "SSE2 is not used")
+endif(USE_SSE2)
 
 
 # tester

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(libdivide)
+
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+target_compile_definitions(${PROJECT_NAME} INTERFACE $<$<CONFIG:Debug>:LIBDIVIDE_ASSERTIONS_ON=1>)
+target_compile_options(${PROJECT_NAME} INTERFACE
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-fstrict-aliasing -Wall -Wextra>
+    )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,15 @@ if(BUILD_BENCHMARK)
     target_compile_definitions(benchmark PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif(BUILD_BENCHMARK)
 
+# primes
+option(BUILD_PRIMES "build primes executable" ON)
+if(BUILD_PRIMES)
+    add_executable(primes primes_benchmark.cpp)
+    target_link_libraries(primes ${PROJECT_NAME})
+    set_target_properties(primes PROPERTIES CXX_STANDARD_REQUIRED 11
+                                            CXX_STANDARD 14)
+endif(BUILD_PRIMES)
+
 # CTest
 option(ENABLE_TESTING "enable testing with CTest" ON)
 if(ENABLE_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,12 @@ target_compile_definitions(${PROJECT_NAME} INTERFACE $<$<CONFIG:Debug>:LIBDIVIDE
 target_compile_options(${PROJECT_NAME} INTERFACE
     $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-fstrict-aliasing -Wall -Wextra>
     )
+
+
+# tester
+option(BUILD_TESTER "build tester executable" ON)
+if(BUILD_TESTER)
+    find_package(Threads)
+    add_executable(tester libdivide_test.cpp)
+    target_link_libraries(tester ${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
+endif(BUILD_TESTER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,9 @@ add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_compile_definitions(${PROJECT_NAME} INTERFACE $<$<CONFIG:Debug>:LIBDIVIDE_ASSERTIONS_ON=1>)
 target_compile_options(${PROJECT_NAME} INTERFACE
-    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-fstrict-aliasing -Wall -Wextra>
+    $<BUILD_INTERFACE:
+        $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:
+            -fstrict-aliasing -Wall -Wextra>>
     )
 if(USE_SSE2)
     message(STATUS "SSE2 is used")
@@ -27,6 +29,34 @@ if(USE_SSE2)
 else(USE_SSE2)
     message(STATUS "SSE2 is not used")
 endif(USE_SSE2)
+
+# install and export variables
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(include_install_dir "include")
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(project_config "${generated_dir}/${PROJECT_NAME}-config.cmake")
+set(version_config "${generated_dir}/${PROJECT_NAME}-config-version.cmake")
+set(targets_export_name "${PROJECT_NAME}-targets")
+set(namespace "${PROJECT_NAME}::")
+
+# ALIAS same as in configure file
+# the ALIAS can be used to create examples which use the same syntax as a client
+# application, which uses `find_package(libdivide CONFIG)`
+# create the alias libdivide::libdivide
+add_library(${namespace}${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+# installation of target libdivide
+install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${targets_export_name}
+    COMPONENT library
+    INCLUDES DESTINATION include # set include path for installed library target
+)
+# installation of header file
+install(
+    FILES libdivide.h
+    DESTINATION include
+)
 
 
 # tester
@@ -66,3 +96,45 @@ if(ENABLE_TESTING)
         add_test(tester-s64 tester "s64")
     endif(BUILD_TESTER)
 endif(ENABLE_TESTING)
+
+
+# Include module for fuctions
+# - 'write_basic_package_version_file'
+# - 'configure_package_config_file'
+include(CMakePackageConfigHelpers)
+
+# enable this block to generate and install a version file
+# Configure '<PROJECT-NAME>-config-version.cmake'
+# Note: PROJECT_VERSION_STRING needs to be defined
+#write_basic_package_version_file(
+#    "${version_config}"
+#    VERSION ${PROJECT_VERSION_STRING}
+#    COMPATIBILITY SameMajorVersion
+#)
+# install version file
+#   * <prefix>/lib/cmake/libdivide/libdivide-config-version.cmake
+#install(
+#    FILES "${version_config}"
+#    DESTINATION "${config_install_dir}"
+#)
+
+# Configure '<PROJECT-NAME>-config.cmake'
+configure_package_config_file(
+    "cmake/config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+# install config file
+#   * <prefix>/lib/cmake/libdivide/libdivide-config.cmake
+install(
+    FILES "${project_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+# install targets file
+#   * <prefix>/lib/cmake/libdivide/libdivide-targets.cmake
+install(
+    EXPORT "${targets_export_name}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,3 +16,16 @@ if(BUILD_TESTER)
     add_executable(tester libdivide_test.cpp)
     target_link_libraries(tester ${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
 endif(BUILD_TESTER)
+
+# CTest
+option(ENABLE_TESTING "enable testing with CTest" ON)
+if(ENABLE_TESTING)
+    enable_testing()
+
+    if(BUILD_TESTER)
+        add_test(tester-u32 tester "u32")
+        add_test(tester-u64 tester "u64")
+        add_test(tester-s32 tester "s32")
+        add_test(tester-s64 tester "s64")
+    endif(BUILD_TESTER)
+endif(ENABLE_TESTING)

--- a/README.md
+++ b/README.md
@@ -50,4 +50,24 @@ The benchmarking utility will also verify that each function returns the same va
 
 Before sending in patches to libdivide, please run the tester to completion with all four types, and the benchmark utility for a reasonable period, to ensure that you have not introduced a regression.
 
+Building with CMake
+-------------------
+
+libdivide can be built with CMake from 3.1 upwards. To use CMake to build libdivide use the following commands in the project root directory:
+* `cmake -H. -Bbuilddir -DCMAKE_BUILD_TYPE=[Debug|Release]`
+* `cmake --build builddir`
+
+This builds all projects in the folder `builddir`. Whether SSE2 is used is automatically determined. To override the automatic detection set the option `USE_SSE2` either via CMake GUI or add `-DUSE_SSE2=ON` to the configuration command line.
+
+To run the `tester` executable for all integer types supported use CTest:
+* `cmake --build builddir --target test`
+
+The following options can be used to configure the CMake build:
+
+* `USE_SSE2`: Enables the use of SSE2 instructions throughout the project.
+* `BUILD_TESTER`: Build the `tester` executable. (Default: `ON`)
+* `BUILD_BENCHMARK`: Build the `benchmark` executable. (Default: `ON`)
+* `BUILD_PRIMES`: Build the `primes` executable. (Default: `ON`)
+* `ENABLE_TESTING`: Enable running tester with CTest. (Default: `ON`)
+
 Happy hacking!

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")
+


### PR DESCRIPTION
As mentioned in #34 I added a `CMakeLists.txt` to build libdivide with CMake 3.1 and newer. The build configuration is based on the `Makefile` currently available.

I have tested the CMake build by building *all* projects in Debug and Release configurations and running the `tester` executable for both configurations (in a local CI). The tests were done on the following platforms:

* Ubuntu 14.04 Trusty amd64
* Ubuntu 14.04 Trusty arm (v7)
* Ubuntu 14.04 Trusty x86
* Ubuntu 16.04 Xenial amd64
* Ubuntu 16.04 Xenial arm (v7)
* Ubuntu 16.04 Xenial x86
* Windows 7 / Visual Studio 2014 amd64
* Windows 7 / Visual Studio 2014 x86

What do you @ridiculousfish and @kimwalisch think of this? Did I miss anything?

Possibly open issues:

- [ ] Should build be switched to CMake entirely and `Makefile` and manual Visual Studio project be removed?
- [ ] Should/Can CI with Travis and AppVeyor be switched to CMake?