### PR TITLE
Fix -Wshift-count-overflow on avr

### DIFF
--- a/libdivide.h
+++ b/libdivide.h
@@ -582,7 +582,7 @@ static uint64_t libdivide_128_div_64_to_64(uint64_t u1, uint64_t u0, uint64_t v,
     if (s > 0) {
         // Normalize divisor
         v = v << s;
-        un64 = (u1 << s) | ((u0 >> (64 - s)) & (-s >> 31));
+        un64 = (u1 << s) | ((u0 >> (64 - s)) & (-((int32_t)s) >> 31));
         un10 = u0 << s; // Shift dividend left
     } else {
         // Avoid undefined behavior


### PR DESCRIPTION
Using libdivide on avr results in the following compile time warning/error:
```
include/libdivide.h:585:52: error: right shift count >= width of type [-Werror=shift-count-overflow]
         un64 = (u1 << s) | ((u0 >> (64 - s)) & (-s >> 31));
                                                    ^~
cc1: all warnings being treated as errors
```

I think this change is the correct cast to get the right behaviour on platforms where int is < 32 bits.