### PR TITLE
Added Low level FFI bindings to Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 benchmark
 primes
 tester
-/build*
+/build!(.rs)
 /.vscode
 CMakeCache.txt
 CMakeFiles
@@ -14,3 +14,12 @@ Makefile
 cmake_install.cmake
 install_manifest.txt
 CTestTestfile.cmake
+
+
+#Added by cargo
+#
+#already existing elements are commented out
+
+/target
+**/*.rs.bk
+Cargo.lock


### PR DESCRIPTION
This allows users to call libdivide's methods from Rust in an unsafe manner.

Higher level API may be added later on demand. 