### PR TITLE
Accelerate counting of leading zeros

### DIFF
--- a/libdivide.h
+++ b/libdivide.h
@@ -290,10 +290,17 @@ static inline int32_t libdivide_count_leading_zeros32(uint32_t val) {
     }
     return 0;
 #else
-    int32_t result = 0;
-    uint32_t hi = 1U << 31;
-    for (; ~val & hi; hi >>= 1) {
-        result++;
+    if (val == 0)
+        return 32;
+    int32_t result = 8;
+    uint32_t hi = 0xFFU << 24;
+    while ((val & hi) == 0) {
+        hi >>= 8;
+        result += 8;
+    }
+    while (val & hi) {
+        result -= 1;
+        hi <<= 1;
     }
     return result;
 #endif


### PR DESCRIPTION
Replace the algorithm for counting leading zeros (in the case of no builtin function)
by one that searches the number in larger chunks first.
This can speed up the counting by up to 10x in the case of small numbers (lots of zeros).

Both tester as well as benchmark_branchfree complete successfully with the new approach. It has also been confirmed explicitly that the results of the old and the new approach agree for all numbers less than 10,000,000.

The process of searching larger chunks first before going bitwise can probably be extended even more to speed it up even further, but this way appears to be a good compromise between legibility and speed.