### PR TITLE
Add ARM CI builds using Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,39 @@
+kind: pipeline
+name: arm
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+- name: build
+  image: alpine
+  commands:
+  - apk update
+  - apk add --no-cache build-base cmake
+  - mkdir build && cd build
+  - cmake .. -DCMAKE_BUILD_TYPE=Release
+  - cmake --build . --parallel
+  - ./tester
+  - ./benchmark_branchfree
+
+---
+
+kind: pipeline
+name: arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: alpine
+  commands:
+  - apk update
+  - apk add --no-cache build-base cmake
+  - mkdir build && cd build
+  - cmake .. -DCMAKE_BUILD_TYPE=Release
+  - cmake --build . --parallel
+  - ./tester
+  - ./benchmark_branchfree


### PR DESCRIPTION
I setup some CI tests running on ARM hardware (32-bit and 64-bit builds) using Drone CI (https://cloud.drone.io/ for setting up -- uses webhooks).

The benchmark results are interesting, it looks like for 32-bit ARM builds branchfree is faster than the system divide for 32-bit datatypes, but 64-bit builds the benchmark results are all pretty similar.