### PR TITLE
Change exit to abort

### DIFF
--- a/libdivide.h
+++ b/libdivide.h
@@ -76,7 +76,7 @@
     do { \
         fprintf(stderr, "libdivide.h:%d: %s(): Error: %s\n", \
             __LINE__, LIBDIVIDE_FUNCTION, msg); \
-        exit(-1); \
+        abort(); \
     } while (0)
 
 #if defined(LIBDIVIDE_ASSERTIONS_ON)
@@ -85,7 +85,7 @@
             if (!(x)) { \
                 fprintf(stderr, "libdivide.h:%d: %s(): Assertion failed: %s\n", \
                     __LINE__, LIBDIVIDE_FUNCTION, #x); \
-                exit(-1); \
+                abort(); \
             } \
         } while (0)
 #else
@@ -2037,7 +2037,7 @@ public:
 
 private:
     // Storage for the actual divisor
-    dispatcher<std::is_integral<T>::value, 
+    dispatcher<std::is_integral<T>::value,
                std::is_signed<T>::value, sizeof(T), ALGO> div;
 };
 


### PR DESCRIPTION
https://github.com/ridiculousfish/libdivide/issues/64

\+ remove one trailing space (this is non-significant).