### PR TITLE
Fix make_unsigned trait in avr_type_helpers.h

### DIFF
--- a/test/avr_type_helpers.h
+++ b/test/avr_type_helpers.h
@@ -11,16 +11,16 @@ namespace std
         typedef _IntT type;  
     };
     template <>
-    struct make_unsigned<uint16_t> {
-        typedef int16_t type;  
+    struct make_unsigned<int16_t> {
+        typedef uint16_t type;  
     };
     template <>
-    struct make_unsigned<uint32_t> {
-        typedef int32_t type;  
+    struct make_unsigned<int32_t> {
+        typedef uint32_t type;  
     };
     template <>
-    struct make_unsigned<uint64_t> {
-        typedef int64_t type;  
+    struct make_unsigned<int64_t> {
+        typedef uint64_t type;  
     };
 
     static const uint8_t CHAR_BIT = 8;


### PR DESCRIPTION
@adbancroft 

The `make_unsigned` trait used by the AVR tests doesn't appear to do the right thing. I think there are some typos. As implemented, it seems to behave as you'd expect from a `make_signed` trait.  Specifically, signed integral types are left unchanged by the trait, and for the unsigned types where there are specialisations, the trait actually *adds* signedness.

This PR ought to fix the issue, I think.