### PR TITLE
Tester program: enable vector tests

### DIFF
--- a/test/DivideTest.h
+++ b/test/DivideTest.h
@@ -34,7 +34,7 @@ using namespace libdivide;
 
 #define UNUSED(x) (void)(x)
 
-#if defined(LIBDIVIDE_SSE2) && defined(LIBDIVIDE_AVX2) && defined(LIBDIVIDE_AVX512) && defined(LIBDIVIDE_NEON)
+#if defined(LIBDIVIDE_SSE2) || defined(LIBDIVIDE_AVX2) || defined(LIBDIVIDE_AVX512) || defined(LIBDIVIDE_NEON)
 #define VECTOR_TESTS
 #endif
 


### PR DESCRIPTION
The `tester` executable wasn't running vector tests: logic error in defining `VECTOR_TESTS` preprocessor symbol in `DivideTest.h`