### PR TITLE
Fix compilation of primitive types

### DIFF
--- a/libdivide.h
+++ b/libdivide.h
@@ -37,7 +37,7 @@
 // disable warning C4146: unary minus operator applied
 // to unsigned type, result still unsigned
 #pragma warning(disable : 4146)
-// disable warning C4204: nonstandard extension used : non-constant aggregate 
+// disable warning C4204: nonstandard extension used : non-constant aggregate
 // initializer
 //
 // It's valid C99
@@ -235,14 +235,12 @@ static LIBDIVIDE_INLINE struct libdivide_u32_branchfree_t libdivide_u32_branchfr
 static LIBDIVIDE_INLINE struct libdivide_s64_branchfree_t libdivide_s64_branchfree_gen(int64_t d);
 static LIBDIVIDE_INLINE struct libdivide_u64_branchfree_t libdivide_u64_branchfree_gen(uint64_t d);
 
-static LIBDIVIDE_INLINE int16_t libdivide_s16_do_raw(
-    int16_t numer, int16_t magic, uint8_t more);
+static LIBDIVIDE_INLINE int16_t libdivide_s16_do_raw(int16_t numer, int16_t magic, uint8_t more);
 static LIBDIVIDE_INLINE int16_t libdivide_s16_do(
-    int16_t numer, const struct libdivide_s16_t* denom);
-static LIBDIVIDE_INLINE uint16_t libdivide_u16_do_raw(
-    uint16_t numer, uint16_t magic, uint8_t more);    
+    int16_t numer, const struct libdivide_s16_t *denom);
+static LIBDIVIDE_INLINE uint16_t libdivide_u16_do_raw(uint16_t numer, uint16_t magic, uint8_t more);
 static LIBDIVIDE_INLINE uint16_t libdivide_u16_do(
-    uint16_t numer, const struct libdivide_u16_t* denom);
+    uint16_t numer, const struct libdivide_u16_t *denom);
 static LIBDIVIDE_INLINE int32_t libdivide_s32_do(
     int32_t numer, const struct libdivide_s32_t *denom);
 static LIBDIVIDE_INLINE uint32_t libdivide_u32_do(
@@ -253,9 +251,9 @@ static LIBDIVIDE_INLINE uint64_t libdivide_u64_do(
     uint64_t numer, const struct libdivide_u64_t *denom);
 
 static LIBDIVIDE_INLINE int16_t libdivide_s16_branchfree_do(
-    int16_t numer, const struct libdivide_s16_branchfree_t* denom);
+    int16_t numer, const struct libdivide_s16_branchfree_t *denom);
 static LIBDIVIDE_INLINE uint16_t libdivide_u16_branchfree_do(
-    uint16_t numer, const struct libdivide_u16_branchfree_t* denom);
+    uint16_t numer, const struct libdivide_u16_branchfree_t *denom);
 static LIBDIVIDE_INLINE int32_t libdivide_s32_branchfree_do(
     int32_t numer, const struct libdivide_s32_branchfree_t *denom);
 static LIBDIVIDE_INLINE uint32_t libdivide_u32_branchfree_do(
@@ -265,17 +263,17 @@ static LIBDIVIDE_INLINE int64_t libdivide_s64_branchfree_do(
 static LIBDIVIDE_INLINE uint64_t libdivide_u64_branchfree_do(
     uint64_t numer, const struct libdivide_u64_branchfree_t *denom);
 
-static LIBDIVIDE_INLINE int16_t libdivide_s16_recover(const struct libdivide_s16_t* denom);
-static LIBDIVIDE_INLINE uint16_t libdivide_u16_recover(const struct libdivide_u16_t* denom);
+static LIBDIVIDE_INLINE int16_t libdivide_s16_recover(const struct libdivide_s16_t *denom);
+static LIBDIVIDE_INLINE uint16_t libdivide_u16_recover(const struct libdivide_u16_t *denom);
 static LIBDIVIDE_INLINE int32_t libdivide_s32_recover(const struct libdivide_s32_t *denom);
 static LIBDIVIDE_INLINE uint32_t libdivide_u32_recover(const struct libdivide_u32_t *denom);
 static LIBDIVIDE_INLINE int64_t libdivide_s64_recover(const struct libdivide_s64_t *denom);
 static LIBDIVIDE_INLINE uint64_t libdivide_u64_recover(const struct libdivide_u64_t *denom);
 
 static LIBDIVIDE_INLINE int16_t libdivide_s16_branchfree_recover(
-    const struct libdivide_s16_branchfree_t* denom);
+    const struct libdivide_s16_branchfree_t *denom);
 static LIBDIVIDE_INLINE uint16_t libdivide_u16_branchfree_recover(
-    const struct libdivide_u16_branchfree_t* denom);
+    const struct libdivide_u16_branchfree_t *denom);
 static LIBDIVIDE_INLINE int32_t libdivide_s32_branchfree_recover(
     const struct libdivide_s32_branchfree_t *denom);
 static LIBDIVIDE_INLINE uint32_t libdivide_u32_branchfree_recover(
@@ -393,7 +391,7 @@ static LIBDIVIDE_INLINE int16_t libdivide_count_leading_zeros16(uint16_t val) {
 
 static LIBDIVIDE_INLINE int32_t libdivide_count_leading_zeros32(uint32_t val) {
 #if defined(__AVR__)
-   // Fast way to count leading zeros
+    // Fast way to count leading zeros
     return __builtin_clzl(val);
 #elif defined(__GNUC__) || __has_builtin(__builtin_clz)
     // Fast way to count leading zeros
@@ -442,7 +440,7 @@ static LIBDIVIDE_INLINE int32_t libdivide_count_leading_zeros64(uint64_t val) {
 // uint {v}. The result must fit in 16 bits.
 // Returns the quotient directly and the remainder in *r
 static LIBDIVIDE_INLINE uint16_t libdivide_32_div_16_to_16(
-    uint16_t u1, uint16_t u0, uint16_t v, uint16_t* r) {
+    uint16_t u1, uint16_t u0, uint16_t v, uint16_t *r) {
     uint32_t n = ((uint32_t)u1 << 16) | u0;
     uint16_t result = (uint16_t)(n / v);
     *r = (uint16_t)(n - result * (uint32_t)v);
@@ -696,8 +694,7 @@ static LIBDIVIDE_INLINE struct libdivide_u16_t libdivide_internal_u16_gen(
         // 1 in its recovery algorithm.
         result.magic = 0;
         result.more = (uint8_t)(floor_log_2_d - (branchfree != 0));
-    }
-    else {
+    } else {
         uint8_t more;
         uint16_t rem, proposed_m;
         proposed_m = libdivide_32_div_16_to_16((uint16_t)1 << floor_log_2_d, 0, d, &rem);
@@ -709,8 +706,7 @@ static LIBDIVIDE_INLINE struct libdivide_u16_t libdivide_internal_u16_gen(
         if (!branchfree && (e < ((uint16_t)1 << floor_log_2_d))) {
             // This power works
             more = floor_log_2_d;
-        }
-        else {
+        } else {
             // We have to use the general 17-bit algorithm.  We need to compute
             // (2**power) / d. However, we already have (2**(power-1))/d and
             // its remainder.  By doubling both, and then correcting the
@@ -742,7 +738,7 @@ struct libdivide_u16_branchfree_t libdivide_u16_branchfree_gen(uint16_t d) {
     }
     struct libdivide_u16_t tmp = libdivide_internal_u16_gen(d, 1);
     struct libdivide_u16_branchfree_t ret = {
-        tmp.magic, (uint8_t)(tmp.more & LIBDIVIDE_16_SHIFT_MASK) };
+        tmp.magic, (uint8_t)(tmp.more & LIBDIVIDE_16_SHIFT_MASK)};
     return ret;
 }
 
@@ -752,27 +748,25 @@ struct libdivide_u16_branchfree_t libdivide_u16_branchfree_gen(uint16_t d) {
 uint16_t libdivide_u16_do_raw(uint16_t numer, uint16_t magic, uint8_t more) {
     if (!magic) {
         return numer >> more;
-    }
-    else {
+    } else {
         uint16_t q = libdivide_mullhi_u16(magic, numer);
         if (more & LIBDIVIDE_ADD_MARKER) {
             uint16_t t = ((numer - q) >> 1) + q;
             return t >> (more & LIBDIVIDE_16_SHIFT_MASK);
-        }
-        else {
+        } else {
             // All upper bits are 0,
             // don't need to mask them off.
             return q >> more;
         }
-    }    
+    }
 }
 
-uint16_t libdivide_u16_do(uint16_t numer, const struct libdivide_u16_t* denom) {
+uint16_t libdivide_u16_do(uint16_t numer, const struct libdivide_u16_t *denom) {
     return libdivide_u16_do_raw(numer, denom->magic, denom->more);
 }
 
 uint16_t libdivide_u16_branchfree_do(
-    uint16_t numer, const struct libdivide_u16_branchfree_t* denom) {
+    uint16_t numer, const struct libdivide_u16_branchfree_t *denom) {
     uint16_t q = libdivide_mullhi_u16(denom->magic, numer);
     uint16_t t = ((numer - q) >> 1) + q;
     return t >> denom->more;
@@ -800,7 +794,7 @@ uint16_t libdivide_u16_recover(const struct libdivide_u16_t *denom) {
         // overflow. So we have to compute it as 2^(16+shift)/(m+2^16), and
         // then double the quotient and remainder.
         uint32_t half_n = (uint32_t)1 << (16 + shift);
-        uint32_t d = ( (uint32_t)1 << 16) | denom->magic;
+        uint32_t d = ((uint32_t)1 << 16) | denom->magic;
         // Note that the quotient is guaranteed <= 16 bits, but the remainder
         // may need 17!
         uint16_t half_q = (uint16_t)(half_n / d);
@@ -1685,18 +1679,18 @@ int64_t libdivide_s64_branchfree_recover(const struct libdivide_s64_branchfree_t
 //
 // Use a union to read a vector via pointer-to-integer, without violating strict
 // aliasing.
-#define SIMPLE_VECTOR_DIVISION(IntT, VecT, Algo) \
-    const size_t count = sizeof(VecT) / sizeof(IntT); \
-    union type_pun_vec { \
-        VecT vec; \
-        IntT arr[sizeof(VecT) / sizeof(IntT)]; \
-    }; \
-    union type_pun_vec result; \
-    union type_pun_vec input; \
-    input.vec = numers; \
-    for (size_t loop=0; loop<count; ++loop) { \
+#define SIMPLE_VECTOR_DIVISION(IntT, VecT, Algo)                          \
+    const size_t count = sizeof(VecT) / sizeof(IntT);                     \
+    union type_pun_vec {                                                  \
+        VecT vec;                                                         \
+        IntT arr[sizeof(VecT) / sizeof(IntT)];                            \
+    };                                                                    \
+    union type_pun_vec result;                                            \
+    union type_pun_vec input;                                             \
+    input.vec = numers;                                                   \
+    for (size_t loop = 0; loop < count; ++loop) {                         \
         result.arr[loop] = libdivide_##Algo##_do(input.arr[loop], denom); \
-    } \
+    }                                                                     \
     return result.vec;
 
 #if defined(LIBDIVIDE_NEON)
@@ -1811,13 +1805,12 @@ static LIBDIVIDE_INLINE int64x2_t libdivide_mullhi_s64_vec128(int64x2_t x, int64
 
 ////////// UINT16
 
-uint16x8_t libdivide_u16_do_vec128(uint16x8_t numers, const struct libdivide_u16_t *denom) {
-    SIMPLE_VECTOR_DIVISION(uint16_t, uint16x8_t, u16)
-}
+uint16x8_t libdivide_u16_do_vec128(uint16x8_t numers, const struct libdivide_u16_t *denom){
+    SIMPLE_VECTOR_DIVISION(uint16_t, uint16x8_t, u16)}
 
-uint16x8_t libdivide_u16_branchfree_do_vec128(uint16x8_t numers, const struct libdivide_u16_branchfree_t *denom) {
-    SIMPLE_VECTOR_DIVISION(uint16_t, uint16x8_t, u16_branchfree)
-}
+uint16x8_t libdivide_u16_branchfree_do_vec128(
+    uint16x8_t numers, const struct libdivide_u16_branchfree_t *denom){
+    SIMPLE_VECTOR_DIVISION(uint16_t, uint16x8_t, u16_branchfree)}
 
 ////////// UINT32
 
@@ -1877,13 +1870,12 @@ uint64x2_t libdivide_u64_branchfree_do_vec128(
 
 ////////// SINT16
 
-int16x8_t libdivide_s16_do_vec128(int16x8_t numers, const struct libdivide_s16_t *denom) {
-    SIMPLE_VECTOR_DIVISION(int16_t, int16x8_t, s16)
-}
+int16x8_t libdivide_s16_do_vec128(int16x8_t numers, const struct libdivide_s16_t *denom){
+    SIMPLE_VECTOR_DIVISION(int16_t, int16x8_t, s16)}
 
-int16x8_t libdivide_s16_branchfree_do_vec128(int16x8_t numers, const struct libdivide_s16_branchfree_t *denom) {
-    SIMPLE_VECTOR_DIVISION(int16_t, int16x8_t, s16_branchfree)
-}
+int16x8_t libdivide_s16_branchfree_do_vec128(
+    int16x8_t numers, const struct libdivide_s16_branchfree_t *denom){
+    SIMPLE_VECTOR_DIVISION(int16_t, int16x8_t, s16_branchfree)}
 
 ////////// SINT32
 
@@ -2089,13 +2081,12 @@ static LIBDIVIDE_INLINE __m512i libdivide_mullhi_s64_vec512(__m512i x, __m512i y
 
 ////////// UINT16
 
-__m512i libdivide_u16_do_vec512(__m512i numers, const struct libdivide_u16_t *denom) {
-    SIMPLE_VECTOR_DIVISION(uint16_t, __m512i, u16)
-}
+__m512i libdivide_u16_do_vec512(__m512i numers, const struct libdivide_u16_t *denom){
+    SIMPLE_VECTOR_DIVISION(uint16_t, __m512i, u16)}
 
-__m512i libdivide_u16_branchfree_do_vec512(__m512i numers, const struct libdivide_u16_branchfree_t *denom) {
-    SIMPLE_VECTOR_DIVISION(uint16_t, __m512i, u16_branchfree)
-}
+__m512i libdivide_u16_branchfree_do_vec512(
+    __m512i numers, const struct libdivide_u16_branchfree_t *denom){
+    SIMPLE_VECTOR_DIVISION(uint16_t, __m512i, u16_branchfree)}
 
 ////////// UINT32
 
@@ -2153,13 +2144,12 @@ __m512i libdivide_u64_branchfree_do_vec512(
 
 ////////// SINT16
 
-__m512i libdivide_s16_do_vec512(__m512i numers, const struct libdivide_s16_t *denom) {
-    SIMPLE_VECTOR_DIVISION(int16_t, __m512i, s16)
-}
+__m512i libdivide_s16_do_vec512(__m512i numers, const struct libdivide_s16_t *denom){
+    SIMPLE_VECTOR_DIVISION(int16_t, __m512i, s16)}
 
-__m512i libdivide_s16_branchfree_do_vec512(__m512i numers, const struct libdivide_s16_branchfree_t *denom) {
-    SIMPLE_VECTOR_DIVISION(int16_t, __m512i, s16_branchfree)
-}
+__m512i libdivide_s16_branchfree_do_vec512(
+    __m512i numers, const struct libdivide_s16_branchfree_t *denom){
+    SIMPLE_VECTOR_DIVISION(int16_t, __m512i, s16_branchfree)}
 
 ////////// SINT32
 
@@ -2383,13 +2373,14 @@ __m256i libdivide_u16_do_vec256(__m256i numers, const struct libdivide_u16_t *de
         } else {
             return _mm256_srli_epi16(q, more);
         }
-    }    
+    }
 }
 
-__m256i libdivide_u16_branchfree_do_vec256(__m256i numers, const struct libdivide_u16_branchfree_t *denom) {
+__m256i libdivide_u16_branchfree_do_vec256(
+    __m256i numers, const struct libdivide_u16_branchfree_t *denom) {
     __m256i q = _mm256_mulhi_epu16(numers, _mm256_set1_epi16(denom->magic));
     __m256i t = _mm256_adds_epu16(_mm256_srli_epi16(_mm256_subs_epu16(numers, q), 1), q);
-    return _mm256_srli_epi16(t, denom->more);    
+    return _mm256_srli_epi16(t, denom->more);
 }
 
 ////////// UINT32
@@ -2477,7 +2468,8 @@ __m256i libdivide_s16_do_vec256(__m256i numers, const struct libdivide_s16_t *de
     }
 }
 
-__m256i libdivide_s16_branchfree_do_vec256(__m256i numers, const struct libdivide_s16_branchfree_t *denom) {
+__m256i libdivide_s16_branchfree_do_vec256(
+    __m256i numers, const struct libdivide_s16_branchfree_t *denom) {
     int16_t magic = denom->magic;
     uint8_t more = denom->more;
     uint8_t shift = more & LIBDIVIDE_16_SHIFT_MASK;
@@ -2734,10 +2726,11 @@ __m128i libdivide_u16_do_vec128(__m128i numers, const struct libdivide_u16_t *de
         } else {
             return _mm_srli_epi16(q, more);
         }
-    } 
+    }
 }
 
-__m128i libdivide_u16_branchfree_do_vec128(__m128i numers, const struct libdivide_u16_branchfree_t *denom) {
+__m128i libdivide_u16_branchfree_do_vec128(
+    __m128i numers, const struct libdivide_u16_branchfree_t *denom) {
     __m128i q = _mm_mulhi_epu16(numers, _mm_set1_epi16(denom->magic));
     __m128i t = _mm_adds_epu16(_mm_srli_epi16(_mm_subs_epu16(numers, q), 1), q);
     return _mm_srli_epi16(t, denom->more);
@@ -2806,8 +2799,8 @@ __m128i libdivide_s16_do_vec128(__m128i numers, const struct libdivide_s16_t *de
         uint16_t mask = ((uint16_t)1 << shift) - 1;
         __m128i roundToZeroTweak = _mm_set1_epi16(mask);
         // q = numer + ((numer >> 15) & roundToZeroTweak);
-        __m128i q = _mm_add_epi16(
-            numers, _mm_and_si128(_mm_srai_epi16(numers, 15), roundToZeroTweak));
+        __m128i q =
+            _mm_add_epi16(numers, _mm_and_si128(_mm_srai_epi16(numers, 15), roundToZeroTweak));
         q = _mm_srai_epi16(q, shift);
         __m128i sign = _mm_set1_epi16((int8_t)more >> 7);
         // q = (q ^ sign) - sign;
@@ -2828,7 +2821,8 @@ __m128i libdivide_s16_do_vec128(__m128i numers, const struct libdivide_s16_t *de
     }
 }
 
-__m128i libdivide_s16_branchfree_do_vec128(__m128i numers, const struct libdivide_s16_branchfree_t *denom) {
+__m128i libdivide_s16_branchfree_do_vec128(
+    __m128i numers, const struct libdivide_s16_branchfree_t *denom) {
     int16_t magic = denom->magic;
     uint8_t more = denom->more;
     uint8_t shift = more & LIBDIVIDE_16_SHIFT_MASK;
@@ -2844,7 +2838,7 @@ __m128i libdivide_s16_branchfree_do_vec128(__m128i numers, const struct libdivid
     __m128i q_sign = _mm_srai_epi16(q, 15);  // q_sign = q >> 15
     __m128i mask = _mm_set1_epi16(((uint16_t)1 << shift) - is_power_of_2);
     q = _mm_add_epi16(q, _mm_and_si128(q_sign, mask));  // q = q + (q_sign & mask)
-    q = _mm_srai_epi16(q, shift);                          // q >>= shift
+    q = _mm_srai_epi16(q, shift);                       // q >>= shift
     q = _mm_sub_epi16(_mm_xor_si128(q, sign), sign);    // q = (q ^ sign) - sign
     return q;
 }
@@ -2912,8 +2906,8 @@ __m128i libdivide_s64_do_vec128(__m128i numers, const struct libdivide_s64_t *de
         uint64_t mask = ((uint64_t)1 << shift) - 1;
         __m128i roundToZeroTweak = _mm_set1_epi64x(mask);
         // q = numer + ((numer >> 63) & roundToZeroTweak);
-        __m128i q =
-            _mm_add_epi64(numers, _mm_and_si128(libdivide_s64_signbits_vec128(numers), roundToZeroTweak));
+        __m128i q = _mm_add_epi64(
+            numers, _mm_and_si128(libdivide_s64_signbits_vec128(numers), roundToZeroTweak));
         q = libdivide_s64_shift_right_vec128(q, shift);
         __m128i sign = _mm_set1_epi32((int8_t)more >> 7);
         // q = (q ^ sign) - sign;
@@ -3215,12 +3209,14 @@ LIBDIVIDE_INLINE __m512i operator/=(__m512i &n, const divider<T, ALGO> &div) {
 
 #if defined(LIBDIVIDE_NEON)
 template <typename T, Branching ALGO>
-LIBDIVIDE_INLINE typename NeonVecFor<T>::type operator/(typename NeonVecFor<T>::type n, const divider<T, ALGO> &div) {
+LIBDIVIDE_INLINE typename NeonVecFor<T>::type operator/(
+    typename NeonVecFor<T>::type n, const divider<T, ALGO> &div) {
     return div.divide(n);
 }
 
 template <typename T, Branching ALGO>
-LIBDIVIDE_INLINE typename NeonVecFor<T>::type operator/=(typename NeonVecFor<T>::type &n, const divider<T, ALGO> &div) {
+LIBDIVIDE_INLINE typename NeonVecFor<T>::type operator/=(
+    typename NeonVecFor<T>::type &n, const divider<T, ALGO> &div) {
     n = div.divide(n);
     return n;
 }

--- a/test/DivideTest.h
+++ b/test/DivideTest.h
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <string.h> // memcpy
+#include <string.h>  // memcpy
+
 #include "outputs.h"
 
 #if defined(__AVR__)
 #include <Arduino.h>
+
 #include "avr_type_helpers.h"
 typedef String string_class;
 // AVR targets do not have enough memory to track which denominatores
@@ -35,13 +37,14 @@ using namespace libdivide;
 
 #define UNUSED(x) (void)(x)
 
-#if defined(LIBDIVIDE_SSE2) || defined(LIBDIVIDE_AVX2) || defined(LIBDIVIDE_AVX512) || defined(LIBDIVIDE_NEON)
+#if defined(LIBDIVIDE_SSE2) || defined(LIBDIVIDE_AVX2) || defined(LIBDIVIDE_AVX512) || \
+    defined(LIBDIVIDE_NEON)
 #define VECTOR_TESTS
 #endif
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable: 4127) // disable "conditional expression is constant""
+#pragma warning(disable : 4127)  // disable "conditional expression is constant""
 #endif
 
 template <typename T>
@@ -79,11 +82,11 @@ class DivideTest {
     }
 
     T random_denominator() {
-      T denom = get_random();
-      while (denom == 0) {
-          denom = get_random();
-      }
-      return denom;
+        T denom = get_random();
+        while (denom == 0) {
+            denom = get_random();
+        }
+        return denom;
     }
 
     string_class testcase_name(int algo) const {
@@ -116,13 +119,13 @@ class DivideTest {
             PRINT_ERROR(expect);
             PRINT_ERROR(F(", but got "));
             PRINT_ERROR(result);
-            PRINT_ERROR(F("\n"));            
+            PRINT_ERROR(F("\n"));
             exit(1);
         }
     }
 
     template <typename VecType, Branching ALGO>
-    void test_vec(const T * numers, size_t count, T denom, const divider<T, ALGO> &div) {
+    void test_vec(const T *numers, size_t count, T denom, const divider<T, ALGO> &div) {
         // Number of T (E.g. in16_t) that will fit in one VecType (E.g. __m256i)
         const size_t countTinVec = sizeof(VecType) / sizeof(T);
 
@@ -133,7 +136,7 @@ class DivideTest {
             T arr[countTinVec];
         };
 
-        const size_t countVec = (sizeof(T)*count)/sizeof(VecType);
+        const size_t countVec = (sizeof(T) * count) / sizeof(VecType);
         for (size_t j = 0; j < countVec; j++, numers += countTinVec) {
             type_pun_vec vec_in;
             memcpy(vec_in.arr, numers, sizeof(VecType));
@@ -154,15 +157,15 @@ class DivideTest {
                     PRINT_ERROR(F(" / "));
                     PRINT_ERROR(denom);
                     PRINT_ERROR(F(" = "));
-                    PRINT_ERROR(expect );
+                    PRINT_ERROR(expect);
                     PRINT_ERROR(F(", but got "));
                     PRINT_ERROR(result);
                     PRINT_ERROR(F("\n"));
                     exit(1);
                 } else {
-    #if 0
+#if 0
                         std::cout << "vec" << (CHAR_BIT * sizeof(VecType)) << " success for: " << numer << " / " << denom << " = " << result << std::endl;
-    #endif
+#endif
                 }
             }
         }
@@ -183,42 +186,36 @@ class DivideTest {
 #endif
 #ifdef LIBDIVIDE_NEON
         typename NeonVecFor<T>::type s5;
-#endif  
-    };    
-    static const size_t min_vector_count = sizeof(union vector_size_u)/sizeof(T);
+#endif
+    };
+    static const size_t min_vector_count = sizeof(union vector_size_u) / sizeof(T);
 
     static constexpr T min = (std::numeric_limits<T>::min)();
-    static constexpr T max = (std::numeric_limits<T>::max)(); 
-    static constexpr T edgeCases[] = {
-        0,					(T)(1),				(T)(2),					(T)(3),				(T)(4),				(T)(5),
-        (T)(6),				(T)(7),				(T)(8),					(T)(9),				(T)(10),			(T)(11),
-        (T)(12),			(T)(13),			(T)(14),				(T)(15),			(T)(16),			(T)(17),
-        (T)(18),			(T)(19),			(T)(20),				(T)(21),			(T)(22),			(T)(23),
-        (T)(24),			(T)(25),			(T)(26),				(T)(27),			(T)(28),			(T)(29),
-        (T)(30),			(T)(31),			(T)(32),				(T)(33),			(T)(34),			(T)(35),
-        (T)(36),			(T)(37),			(T)(38),				(T)(39),			(T)(40),			(T)(41),
-        (T)(42),			(T)(43),			(T)(44),				(T)(45),			(T)(46),			(T)(47),
-        (T)(48),			(T)(49),			(T)(123),				(T)(1232),			(T)(36847),			(T)(506838),
-        (T)(3000003),		(T)(70000007),		
+    static constexpr T max = (std::numeric_limits<T>::max)();
+    static constexpr T edgeCases[] = {0, (T)(1), (T)(2), (T)(3), (T)(4), (T)(5), (T)(6), (T)(7),
+        (T)(8), (T)(9), (T)(10), (T)(11), (T)(12), (T)(13), (T)(14), (T)(15), (T)(16), (T)(17),
+        (T)(18), (T)(19), (T)(20), (T)(21), (T)(22), (T)(23), (T)(24), (T)(25), (T)(26), (T)(27),
+        (T)(28), (T)(29), (T)(30), (T)(31), (T)(32), (T)(33), (T)(34), (T)(35), (T)(36), (T)(37),
+        (T)(38), (T)(39), (T)(40), (T)(41), (T)(42), (T)(43), (T)(44), (T)(45), (T)(46), (T)(47),
+        (T)(48), (T)(49), (T)(123), (T)(1232), (T)(36847), (T)(506838), (T)(3000003), (T)(70000007),
 
-        (T)(max),			(T)(max - 1),		(T)(max - 2),			(T)(max - 3),		(T)(max - 4),		(T)(max - 5),
-        (T)(max - 3213),	(T)(max - 2453242),	(T)(max - 432234231),	
+        (T)(max), (T)(max - 1), (T)(max - 2), (T)(max - 3), (T)(max - 4), (T)(max - 5),
+        (T)(max - 3213), (T)(max - 2453242), (T)(max - 432234231),
 
-        (T)(min),			(T)(min + 1),		(T)(min + 2),			(T)(min + 3),		(T)(min + 4),		(T)(min + 5),
-        (T)(min + 3213),	(T)(min + 2453242),	(T)(min + 432234231),	
+        (T)(min), (T)(min + 1), (T)(min + 2), (T)(min + 3), (T)(min + 4), (T)(min + 5),
+        (T)(min + 3213), (T)(min + 2453242), (T)(min + 432234231),
 
-        (T)(max / 2),		(T)(max / 2 + 1),	(T)(max / 2 - 1),		(T)(max / 3),		(T)(max / 3 + 1),	(T)(max / 3 - 1),	
-        (T)(max / 4),		(T)(max / 4 + 1),	(T)(max / 4 - 1),
+        (T)(max / 2), (T)(max / 2 + 1), (T)(max / 2 - 1), (T)(max / 3), (T)(max / 3 + 1),
+        (T)(max / 3 - 1), (T)(max / 4), (T)(max / 4 + 1), (T)(max / 4 - 1),
 
-        (T)(min / 2),		(T)(min / 2 + 1),	(T)(min / 2 - 1),		(T)(min / 3),		(T)(min / 3 + 1),	(T)(min / 3 - 1),
-        (T)(min / 4),		(T)(min / 4 + 1),	(T)(min / 4 - 1)
-    };
+        (T)(min / 2), (T)(min / 2 + 1), (T)(min / 2 - 1), (T)(min / 3), (T)(min / 3 + 1),
+        (T)(min / 3 - 1), (T)(min / 4), (T)(min / 4 + 1), (T)(min / 4 - 1)};
 
     template <Branching ALGO>
     void test_edgecase_numerators(T denom, const divider<T, ALGO> &the_divider) {
         for (auto numerator : edgeCases) {
             test_one((T)numerator, denom, the_divider);
-        }        
+        }
     }
 
     template <Branching ALGO>
@@ -241,7 +238,7 @@ class DivideTest {
 
     template <Branching ALGO>
     void test_pow2_numerators(T denom, const divider<T, ALGO> &the_divider) {
-       // test power of 2 numerators: 2^i-1, 2^i, 2^i+1
+        // test power of 2 numerators: 2^i-1, 2^i, 2^i+1
         for (int i = 1; i < limits::digits; i++) {
             for (int j = -1; j <= 1; j++) {
                 T numerator = static_cast<T>((static_cast<T>(1) << i) + j);
@@ -269,12 +266,12 @@ class DivideTest {
             for (size_t j = 0; j < min_vector_count; j++) {
                 test_one(get_random(), denom, the_divider);
             }
-        }        
+        }
     }
 
     template <Branching ALGO>
     void test_vectordivide_numerators(T denom, const divider<T, ALGO> &the_divider) {
-#if defined(VECTOR_TESTS)        
+#if defined(VECTOR_TESTS)
         // Align memory to 64 byte boundary for AVX512
         char mem[min_vector_count * sizeof(T) + 64];
         size_t offset = 64 - (size_t)&mem % 64;
@@ -299,13 +296,13 @@ class DivideTest {
         }
 #else
         UNUSED(denom);
-        UNUSED(the_divider);        
+        UNUSED(the_divider);
 #endif
     }
 
     template <Branching ALGO>
     void test_all_numerators(T denom, const divider<T, ALGO> &the_divider) {
-        for (T numerator=(min); numerator!=(max); ++numerator) {
+        for (T numerator = (min); numerator != (max); ++numerator) {
             test_one((T)numerator, denom, the_divider);
         }
     }
@@ -343,7 +340,7 @@ class DivideTest {
     static uint32_t randomSeed() {
 #if defined(__AVR__)
         return (uint32_t)analogRead(A0);
-#else   
+#else
         std::random_device randomDevice;
         std::mt19937 randGen(randomDevice());
         std::uniform_int_distribution<uint32_t> randDist(1, std::numeric_limits<uint32_t>::max());
@@ -353,7 +350,7 @@ class DivideTest {
 
     void test_all_algorithms(T denom, set_t<T> &tested_denom) {
 #if !defined(__AVR__)
-        if(tested_denom.end()==tested_denom.find(denom)) {
+        if (tested_denom.end() == tested_denom.find(denom)) {
 #endif
             PRINT_PROGRESS_MSG(F("Testing deom "));
             PRINT_PROGRESS_MSG(denom);
@@ -362,7 +359,7 @@ class DivideTest {
             test_many<BRANCHFREE>(denom);
 #if !defined(__AVR__)
             tested_denom.insert(denom);
-        } 
+        }
 #else
         UNUSED(tested_denom);
 #endif
@@ -373,11 +370,10 @@ class DivideTest {
 
         if (limits::is_signed) {
             test_all_algorithms(-denom, tested_denom);
-        }        
+        }
     }
 
-public:
-
+   public:
     DivideTest() {
         seed = randomSeed();
         rand_n = (UT)randomSeed();
@@ -388,8 +384,10 @@ public:
 
         // Test small values
 #if defined(__AVR__)
-        UT primes[] = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173};
-        for (size_t index = 0; index < sizeof(primes)/sizeof(primes[0]); ++index) {
+        UT primes[] = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
+            73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163,
+            167, 173};
+        for (size_t index = 0; index < sizeof(primes) / sizeof(primes[0]); ++index) {
             test_both_signs(primes[index], tested_denom);
         }
 #else
@@ -431,7 +429,7 @@ public:
 
         // Test random denominators
 #if !defined(__AVR__)
-        PRINT_PROGRESS_MSG(F("Test random denominators\n"));        
+        PRINT_PROGRESS_MSG(F("Test random denominators\n"));
         for (int i = 0; i < 10000; ++i) {
             test_all_algorithms(random_denominator(), tested_denom);
         }
@@ -439,7 +437,7 @@ public:
     }
 };
 
-template<typename IntT>
+template <typename IntT>
 constexpr IntT DivideTest<IntT>::edgeCases[];
 
 template <typename T>

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -12,10 +12,11 @@
 // Silence MSVC sprintf unsafe warnings
 #define _CRT_SECURE_NO_WARNINGS
 
-#include <string.h>
 #include "benchmark.h"
 
-int main(int argc, char *argv[]) {   
+#include <string.h>
+
+int main(int argc, char *argv[]) {
     // Disable printf buffering.
     // This is mainly required for Windows.
     setbuf(stdout, NULL);

--- a/test/benchmark.h
+++ b/test/benchmark.h
@@ -22,10 +22,10 @@
 #endif
 
 #include "libdivide.h"
-#include "type_mappings.h"
 #include "outputs.h"
-#include "timer.hpp"
 #include "random_numerators.hpp"
+#include "timer.hpp"
+#include "type_mappings.h"
 
 using namespace libdivide;
 
@@ -67,7 +67,7 @@ template <typename IntT>
 inline uint64_t unsigned_sum_vals(const IntT *vals, size_t count) {
     typedef typename std::make_unsigned<IntT>::type UIntT;
     UIntT sum = 0;
-    for (size_t i=0; i < count; i++) {
+    for (size_t i = 0; i < count; i++) {
         sum += static_cast<UIntT>(vals[i]);
     }
     return sum;
@@ -120,34 +120,41 @@ NOINLINE uint64_t sum_quotients_vec(const random_numerators<IntT> &vals, const D
 #elif defined(LIBDIVIDE_NEON)
 
 // Helper to deduce NEON vector type for integral type.
-template <typename T> struct NeonVecFuncs {};
+template <typename T>
+struct NeonVecFuncs {};
 
-template <> struct NeonVecFuncs<uint16_t> {
+template <>
+struct NeonVecFuncs<uint16_t> {
     static inline uint16x8_t dup(uint16_t value) { return vdupq_n_u16(value); }
     static inline uint16x8_t add(uint16x8_t a, uint16x8_t b) { return vaddq_u16(a, b); }
 };
 
-template <> struct NeonVecFuncs<int16_t> { 
+template <>
+struct NeonVecFuncs<int16_t> {
     static inline int16x8_t dup(int16_t value) { return vdupq_n_s16(value); }
     static inline int16x8_t add(int16x8_t a, int16x8_t b) { return vaddq_s16(a, b); }
 };
 
-template <> struct NeonVecFuncs<uint32_t> {
+template <>
+struct NeonVecFuncs<uint32_t> {
     static inline uint32x4_t dup(uint32_t value) { return vdupq_n_u32(value); }
     static inline uint32x4_t add(uint32x4_t a, uint32x4_t b) { return vaddq_u32(a, b); }
 };
 
-template <> struct NeonVecFuncs<int32_t> { 
+template <>
+struct NeonVecFuncs<int32_t> {
     static inline int32x4_t dup(int32_t value) { return vdupq_n_s32(value); }
     static inline int32x4_t add(int32x4_t a, int32x4_t b) { return vaddq_s32(a, b); }
 };
 
-template <> struct NeonVecFuncs<uint64_t> {
+template <>
+struct NeonVecFuncs<uint64_t> {
     static inline uint64x2_t dup(uint64_t value) { return vdupq_n_u64(value); }
     static inline uint64x2_t add(uint64x2_t a, uint64x2_t b) { return vaddq_u64(a, b); }
 };
 
-template <> struct NeonVecFuncs<int64_t> {
+template <>
+struct NeonVecFuncs<int64_t> {
     static inline int64x2_t dup(int64_t value) { return vdupq_n_s64(value); }
     static inline int64x2_t add(int64x2_t a, int64x2_t b) { return vaddq_s64(a, b); }
 };
@@ -185,11 +192,12 @@ struct time_double {
     uint64_t result;
 };
 
-template<typename IntT, class DenomT>
-using pFuncToTime = uint64_t(*)(const random_numerators<IntT> &, const DenomT &);
+template <typename IntT, class DenomT>
+using pFuncToTime = uint64_t (*)(const random_numerators<IntT> &, const DenomT &);
 
-template<typename IntT, class DenomT>
-NOINLINE static time_double time_function(const random_numerators<IntT> &vals, DenomT denom, pFuncToTime<IntT, DenomT> timeFunc) {
+template <typename IntT, class DenomT>
+NOINLINE static time_double time_function(
+    const random_numerators<IntT> &vals, DenomT denom, pFuncToTime<IntT, DenomT> timeFunc) {
     time_double tresult;
 
     timer t;
@@ -226,8 +234,9 @@ NOINLINE TestResult test_one(const random_numerators<IntT> &vals, IntT denom) {
     divider<IntT, BRANCHFULL> div_bfull(denom);
     divider<IntT, BRANCHFREE> div_bfree(testBranchfree ? denom : 2);
 
-    uint64_t min_my_time = INT64_MAX, min_my_time_branchfree = INT64_MAX, min_my_time_vector = INT64_MAX,
-        min_my_time_vector_branchfree = INT64_MAX, min_his_time = INT64_MAX, min_gen_time = INT64_MAX;
+    uint64_t min_my_time = INT64_MAX, min_my_time_branchfree = INT64_MAX,
+             min_my_time_vector = INT64_MAX, min_my_time_vector_branchfree = INT64_MAX,
+             min_his_time = INT64_MAX, min_gen_time = INT64_MAX;
     time_double tresult;
     for (size_t iter = 0; iter < TEST_COUNT; iter++) {
         tresult = time_function(vals, denom, sum_quotients);
@@ -273,14 +282,14 @@ NOINLINE TestResult test_one(const random_numerators<IntT> &vals, IntT denom) {
     result.base_time = min_my_time / (double)vals.length();
     result.branchfree_time = testBranchfree ? min_my_time_branchfree / (double)vals.length() : -1;
     result.vector_time = min_my_time_vector / (double)vals.length();
-    result.vector_branchfree_time = testBranchfree ? min_my_time_vector_branchfree / (double)vals.length() : -1;
+    result.vector_branchfree_time =
+        testBranchfree ? min_my_time_vector_branchfree / (double)vals.length() : -1;
     result.hardware_time = min_his_time / (double)vals.length();
     return result;
 }
 
 template <typename _IntT>
-int32_t get_algorithm(_IntT d)
-{
+int32_t get_algorithm(_IntT d) {
     const auto denom = libdivide_gen(d);
     uint8_t more = denom.more;
     if (!denom.magic)
@@ -303,8 +312,9 @@ NOINLINE TestResult test_one(_IntT d, const random_numerators<_IntT> &data) {
 
 inline static void print_report_header(void) {
     char buffer[256];
-    sprintf(buffer, "%6s %" PRIcw "s %" PRIcw "s %" PRIcw "s %" PRIcw "s %" PRIcw "s %" PRIcw "s %6s\n", "#", "system", "scalar", "scl_bf", "vector", "vec_bf",
-        "gener", "algo");
+    sprintf(buffer,
+        "%6s %" PRIcw "s %" PRIcw "s %" PRIcw "s %" PRIcw "s %" PRIcw "s %" PRIcw "s %6s\n", "#",
+        "system", "scalar", "scl_bf", "vector", "vec_bf", "gener", "algo");
     PRINT_INFO(buffer);
 }
 
@@ -317,9 +327,10 @@ static void print_report_result(_IntT d, struct TestResult result) {
     char *pDenom = to_str(denom_buff, d);
 
     char report_buff[256];
-    sprintf(report_buff, "%6s %" PRIrc " %" PRIrc " %" PRIrc " %" PRIrc " %" PRIrc " %" PRIrc " %4d\n", pDenom, result.hardware_time, result.base_time,
-        result.branchfree_time, result.vector_time, result.vector_branchfree_time, result.gen_time,
-        result.algo);
+    sprintf(report_buff,
+        "%6s %" PRIrc " %" PRIrc " %" PRIrc " %" PRIrc " %" PRIrc " %" PRIrc " %4d\n", pDenom,
+        result.hardware_time, result.base_time, result.branchfree_time, result.vector_time,
+        result.vector_branchfree_time, result.gen_time, result.algo);
     PRINT_INFO(report_buff);
 }
 
@@ -347,5 +358,5 @@ void test_many() {
         } else {
             d++;
         }
-    }  
+    }
 }

--- a/test/benchmark_branchfree.cpp
+++ b/test/benchmark_branchfree.cpp
@@ -114,7 +114,7 @@ void benchmark(tasks_t tasks, size_t max, size_t iters) {
     result_t branchfree = {0, 0};
 
     size_t st_max = std::min(max, (size_t)std::numeric_limits<T>::max());
-    iters = iters * (max/st_max);
+    iters = iters * (max / st_max);
     T t_max = (T)st_max;
     if (test_system) {
         using divider_type = T;
@@ -159,7 +159,8 @@ void benchmark(tasks_t tasks, size_t max, size_t iters) {
 }
 
 void usage() {
-    std::cout << "Usage: benchmark_branchfree [uu16] [u32] [u64] [s16] [s32] [s64] [branchfree] [branchfull] "
+    std::cout << "Usage: benchmark_branchfree [uu16] [u32] [u64] [s16] [s32] [s64] [branchfree] "
+                 "[branchfull] "
                  "[sys|system]\n"
                  "\n"
                  "The branchfree benchmark iterates over an array of dividers and computes\n"

--- a/test/tester.cpp
+++ b/test/tester.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+
 #include "DivideTest.h"
 #include "libdivide.h"
 
@@ -33,21 +34,19 @@ void wait_for_threads(std::vector<std::thread> &test_threads) {
     }
 }
 
-uint8_t get_max_threads() {
-    return (uint8_t)std::max(1U, std::thread::hardware_concurrency());
-}
+uint8_t get_max_threads() { return (uint8_t)std::max(1U, std::thread::hardware_concurrency()); }
 
-template<typename _IntT>
+template <typename _IntT>
 void launch_test_thread(std::vector<std::thread> &test_threads) {
     static uint8_t max_threads = get_max_threads();
-    
-    if (max_threads==test_threads.size()) {
+
+    if (max_threads == test_threads.size()) {
         wait_for_threads(test_threads);
         test_threads.clear();
-    }    
+    }
     test_threads.emplace_back(run_test<_IntT>);
 }
-    
+
 int main(int argc, char *argv[]) {
     bool default_do_test = (argc <= 1);
     std::vector<bool> do_tests(6, default_do_test);
@@ -122,7 +121,7 @@ int main(int argc, char *argv[]) {
     if (do_tests[type_u64]) {
         launch_test_thread<uint64_t>(test_threads);
     }
-    
+
     wait_for_threads(test_threads);
 
     std::cout << "\nAll tests passed successfully!" << std::endl;

--- a/test/tester.cpp
+++ b/test/tester.cpp
@@ -19,6 +19,23 @@
 #include "DivideTest.h"
 #include "libdivide.h"
 
+// This is simply a regression test for #96: that the following all compile (and don't crash).
+static void test_primitives_compile() {
+    libdivide::divider<short> d0(1);
+    libdivide::divider<int> d1(1);
+    libdivide::divider<long> d2(1);
+    libdivide::divider<long long> d3(1);
+
+    libdivide::divider<unsigned short> u0(1);
+    libdivide::divider<unsigned int> u1(1);
+    libdivide::divider<unsigned long> u2(1);
+    libdivide::divider<unsigned long long> u3(1);
+
+    // These should fail to compile.
+    // libdivide::divider<float> f0(1);
+    // libdivide::divider<double> f1(1);
+}
+
 enum TestType {
     type_s16,
     type_u16,
@@ -50,6 +67,8 @@ void launch_test_thread(std::vector<std::thread> &test_threads) {
 int main(int argc, char *argv[]) {
     bool default_do_test = (argc <= 1);
     std::vector<bool> do_tests(6, default_do_test);
+
+    test_primitives_compile();
 
     for (int i = 1; i < argc; i++) {
         const std::string arg(argv[i]);


### PR DESCRIPTION
To restate #96: currently libdivide "dispatches" based on whether its type is `uint32_t`, `uint64_t`, etc. However these types are mapped to a primitive type like `unsigned int`; if say `unsigned long` has the same width then `divider<unsigned long>` will fail to compile since there is no specialization for it.

The idea here is to go back to a dispatch based on the size and signedness of the type, so that `unsigned long` and `unsigned int` will be handled the same. To detect the signedness we avoid `type_traits` which is apparently unavailable in AVR; instead we use the following trick:

    T(0) > T(-1)

which will be true only for signed types. We can prevent floating point by throwing in a shift:

    (T(0) >> 0) > T(-1)

An inelegant hack for an uncivilized language but it does the job. Fixes #96.