### PR TITLE
Increase minimum CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 set(LIBDIVIDE_VERSION "3.0")
 project(libdivide C CXX)
 


### PR DESCRIPTION
Starting with CMake 3.27, configuring libdivide prints a deprecation warning because compatibility with versions of CMake older than 3.5 is deprecated. This pull request increases the minimum CMake version from 3.4 to 3.5, which resolves the issue.