### PR TITLE
Fix `LIBDIVIDE_VERSION` CMake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-set(LIBDIVIDE_VERSION "3.0")
+set(LIBDIVIDE_VERSION "5.0")
 project(libdivide C CXX)
 
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
This PR updates the `LIBDIVIDE_VERSION` CMake variable to the same value as contained in `libdivide.h`.