### PR TITLE
Include missing CTest module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,7 @@ endif()
 # Enable testing ###############################################
 
 if (LIBDIVIDE_BUILD_TESTS)
+    include(CTest)
     enable_testing()
     add_test(tester tester)
     add_test(benchmark_branchfree benchmark_branchfree)


### PR DESCRIPTION
Currently the libdivide project's `CMakeLists.txt` file sets up tests in a way that makes it possible to run the tests from the build directory by executing the `ctest` command. Yet the `CMakeLists.txt` file does not include the [CTest](https://cmake.org/cmake/help/latest/module/CTest.html) CMake module anywhere. This pull request includes the CTest module in the appropriate location.

I'm actually surprised executing the `ctest` command to run libdivide's tests even worked without including the CTest module in the first place. Maybe one of the other included CMake modules ended up transitively loading the CTest module. This, however, would be undocumented behaviour (AFAIK) that should not be relied on.