### PR TITLE
Only build tests when libdivide is the main project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,13 @@ add_compile_options(
 
 # Build options ################################################
 
-option(LIBDIVIDE_BUILD_TESTS   "Build the test programs" ON)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(MAIN_PROJECT ON)
+else()
+  set(MAIN_PROJECT OFF)
+endif()
+
+option(LIBDIVIDE_BUILD_TESTS   "Build the test programs" "${MAIN_PROJECT}")
 option(LIBDIVIDE_BUILD_FUZZERS "Build the fuzzers (requires clang)" OFF)
 
 # By default we automatically enable vectors supported by


### PR DESCRIPTION
This pull request configures the `LIBDIVIDE_BUILD_TESTS` CMake option to be `ON` only when libdivide is being configured as the main project. This is because building tests by default when libdivide is _not_ the main project can unexpectedly include libdivide's tests into the main project's tests. The fix in this pull request is inspired by an analogous fix in another C++ library [here](https://github.com/nlohmann/json/pull/2514).

The issue can be explained as follows. When a user includes libdivide into their CMake project using [`FetchContent`](https://cmake.org/cmake/help/latest/module/FetchContent.html), CMake fully configures and builds libdivide during the main project's configuration phase and includes libdivide into the main project using [`add_subdirectory`](https://cmake.org/cmake/help/latest/command/add_subdirectory.html). The unexpected consequence is that libdivide's tests get added into the main project's tests that get run using the `ctest` command. Configuring the `LIBDIVIDE_BUILD_TESTS` option to be `OFF` when libdivide is _not_ the main project prevents libdivide's tests from being added into the main project when the user doesn't expect so, but it let's them manually add libdivide's tests if they desire by toggling the `LIBDIVIDE_BUILD_TESTS` option.