### PR TITLE
Fix a typo (division/divsion) in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Integer division is one of the slowest instructions on most CPUs e.g. on
 current x64 CPUs a 64-bit integer division has a latency of up to 90 clock
 cycles whereas a multiplication has a latency of only 3 clock cycles.
-libdivide allows you to replace expensive integer divsion instructions by
+libdivide allows you to replace expensive integer division instructions by
 a sequence of shift, add and multiply instructions that will calculate
 the integer division much faster.
 


### PR DESCRIPTION
Replace typo “divsion” with ”division” in README.md.