### PR TITLE
Publish libdivide to Arduino & PlatformIO library registries

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=libdivide
+version=5.1.0
+author=ridiculousfish
+maintainer=ridiculousfish
+sentence=Optimised integer division.
+paragraph=libdivide.h is a header-only C/C++ library for optimizing integer division. Integer division is one of the slowest instructions on most CPUs e.g. on current x64 CPUs a 64-bit integer division has a latency of up to 90 clock cycles whereas a multiplication has a latency of only 3 clock cycles. libdivide allows you to replace expensive integer division instructions by a sequence of shift, add and multiply instructions that will calculate the integer division much faster.
+category=Data Processing
+url=https://github.com/ridiculousfish/libdivide
+architectures=*


### PR DESCRIPTION
Add library.properties so we can publish libdivide to [Arduino](https://www.arduino.cc/reference/en/libraries/) & [PlatformIO](https://registry.platformio.org/) registries