### PR TITLE
Add constexpr structure generation (C++14 only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,7 +271,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libdivideConfigVersion.cmake"
 if (LIBDIVIDE_BUILD_TESTS)
     find_package(Threads REQUIRED QUIET)
 
-    add_executable(tester test/tester.cpp)
+    add_executable(tester test/tester.cpp test/constexpr_test.cpp)
     add_executable(test_c99 test/test_c99.c)
     add_executable(fast_div_generator test/fast_div_generator.cpp)
     add_executable(benchmark test/benchmark.cpp)

--- a/constant_fast_div.h
+++ b/constant_fast_div.h
@@ -70,8 +70,8 @@
 * constant.
 * E.g. FAST_DIV16U(value, 100)
 */
-#define U16_MAGIC(d) CONCAT(CONCAT(U16LD_DENOM_, d), _MAGIC)
-#define U16_MORE(d) CONCAT(CONCAT(U16LD_DENOM_, d), _MORE)
+#define U16_MAGIC(d) LD_CONCAT(LD_CONCAT(U16LD_DENOM_, d), _MAGIC)
+#define U16_MORE(d) LD_CONCAT(LD_CONCAT(U16LD_DENOM_, d), _MORE)
 #define FAST_DIV16U(a, d) (U16_ISPOW2(d) ? a/d : LIB_DIV_NAMESPACE libdivide_u16_do_raw(a, U16_MAGIC(d), U16_MORE(d)))
 
 /*
@@ -81,8 +81,8 @@
 * This only works for positive parmeters :-(
 * A negative number results in a hypen in the macro name, which is not allowed
 */
-#define S16_MAGIC(d) CONCAT(CONCAT(S16LD_DENOM_, d), _MAGIC)
-#define S16_MORE(d) CONCAT(CONCAT(S16LD_DENOM_, d), _MORE)
+#define S16_MAGIC(d) LD_CONCAT(LD_CONCAT(S16LD_DENOM_, d), _MAGIC)
+#define S16_MORE(d) LD_CONCAT(LD_CONCAT(S16LD_DENOM_, d), _MORE)
 #define FAST_DIV16(a, d) (S16_ISPOW2(d) ? a/d : LIB_DIV_NAMESPACE libdivide_s16_do_raw(a, S16_MAGIC(d), S16_MORE(d))) 
 
 /*
@@ -92,8 +92,8 @@
 * This only works for positive parmeters :-(
 * A negative number results in a hypen in the macro name, which is not allowed
 */
-#define S16_MAGIC_NEG(d) CONCAT(CONCAT(S16LD_DENOM_MINUS_, d), _MAGIC)
-#define S16_MORE_NEG(d) CONCAT(CONCAT(S16LD_DENOM_MINUS_, d), _MORE)
+#define S16_MAGIC_NEG(d) LD_CONCAT(LD_CONCAT(S16LD_DENOM_MINUS_, d), _MAGIC)
+#define S16_MORE_NEG(d) LD_CONCAT(LD_CONCAT(S16LD_DENOM_MINUS_, d), _MORE)
 #define FAST_DIV16_NEG(a, d) (S16_ISPOW2(d) ? a/-d : LIB_DIV_NAMESPACE libdivide_s16_do_raw(a, S16_MAGIC_NEG(d), S16_MORE_NEG(d))) 
 
 /*

--- a/constant_fast_div.h
+++ b/constant_fast_div.h
@@ -23,9 +23,6 @@
 #include "u16_ldparams.h"
 #include "s16_ldparams.h"
 
-#define CAT_HELPER(a, b) a ## b
-#define CONCAT(A, B) CAT_HELPER(A, B)
-
 // GCC will optimise division by a power of 2
 // So allow that.
 #define S16_ISPOW2_NEG(denom) \

--- a/libdivide.h
+++ b/libdivide.h
@@ -116,34 +116,6 @@
 namespace libdivide {
 #endif
 
-// pack divider structs to prevent compilers from padding.
-// This reduces memory usage by up to 43% when using a large
-// array of libdivide dividers and improves performance
-// by up to 10% because of reduced memory bandwidth.
-#pragma pack(push, 1)
-
-#define STRUCT_NAME(tag) libdivide_ ##tag ##_t
-#define STRUCT_BRANCHFREE_NAME(tag) libdivide_ ##tag ##_branchfree_t
-
-#define DEFINE_STRUCTS(tag, type) \
-    struct STRUCT_NAME(tag) { \
-        type magic; \
-        uint8_t more; \
-    }; \
-    struct STRUCT_BRANCHFREE_NAME(tag) { \
-        type magic; \
-        uint8_t more; \
-    };
-
-DEFINE_STRUCTS(s16, int16_t)
-DEFINE_STRUCTS(u16, uint16_t)
-DEFINE_STRUCTS(s32, int32_t)
-DEFINE_STRUCTS(u32, uint32_t)
-DEFINE_STRUCTS(s64, int64_t)
-DEFINE_STRUCTS(u64, uint64_t)
-
-#pragma pack(pop)
-
 // Explanation of the "more" field:
 //
 // * Bits 0-5 is the shift value (for shift path or mult path).
@@ -184,67 +156,63 @@ enum {
     LIBDIVIDE_NEGATIVE_DIVISOR = 0x80
 };
 
-static LIBDIVIDE_INLINE struct libdivide_s16_t libdivide_s16_gen(int16_t d);
-static LIBDIVIDE_INLINE struct libdivide_u16_t libdivide_u16_gen(uint16_t d);
-static LIBDIVIDE_INLINE struct libdivide_s32_t libdivide_s32_gen(int32_t d);
-static LIBDIVIDE_INLINE struct libdivide_u32_t libdivide_u32_gen(uint32_t d);
-static LIBDIVIDE_INLINE struct libdivide_s64_t libdivide_s64_gen(int64_t d);
-static LIBDIVIDE_INLINE struct libdivide_u64_t libdivide_u64_gen(uint64_t d);
+#undef _CONCAT
+#define _CONCAT(x,y) x ## y
+#define CONCAT(x,y)  _CONCAT(x,y)
 
-static LIBDIVIDE_INLINE struct libdivide_s16_branchfree_t libdivide_s16_branchfree_gen(int16_t d);
-static LIBDIVIDE_INLINE struct libdivide_u16_branchfree_t libdivide_u16_branchfree_gen(uint16_t d);
-static LIBDIVIDE_INLINE struct libdivide_s32_branchfree_t libdivide_s32_branchfree_gen(int32_t d);
-static LIBDIVIDE_INLINE struct libdivide_u32_branchfree_t libdivide_u32_branchfree_gen(uint32_t d);
-static LIBDIVIDE_INLINE struct libdivide_s64_branchfree_t libdivide_s64_branchfree_gen(int64_t d);
-static LIBDIVIDE_INLINE struct libdivide_u64_branchfree_t libdivide_u64_branchfree_gen(uint64_t d);
+#define STRUCT_POSTFIX _t
+#define BRANCHFREE_POSTFIX _branchfree_t
+#define _STRUCT_NAME(tag, postfix) CONCAT(libdivide_, CONCAT(tag, postfix))
 
-static LIBDIVIDE_INLINE int16_t libdivide_s16_do_raw(int16_t numer, int16_t magic, uint8_t more);
-static LIBDIVIDE_INLINE int16_t libdivide_s16_do(
-    int16_t numer, const struct libdivide_s16_t *denom);
-static LIBDIVIDE_INLINE uint16_t libdivide_u16_do_raw(uint16_t numer, uint16_t magic, uint8_t more);
-static LIBDIVIDE_INLINE uint16_t libdivide_u16_do(
-    uint16_t numer, const struct libdivide_u16_t *denom);
-static LIBDIVIDE_INLINE int32_t libdivide_s32_do(
-    int32_t numer, const struct libdivide_s32_t *denom);
-static LIBDIVIDE_INLINE uint32_t libdivide_u32_do(
-    uint32_t numer, const struct libdivide_u32_t *denom);
-static LIBDIVIDE_INLINE int64_t libdivide_s64_do(
-    int64_t numer, const struct libdivide_s64_t *denom);
-static LIBDIVIDE_INLINE uint64_t libdivide_u64_do(
-    uint64_t numer, const struct libdivide_u64_t *denom);
+#define STRUCT_NAME(tag) _STRUCT_NAME(tag, STRUCT_POSTFIX)
+#define STRUCT_BRANCHFREE_NAME(tag) _STRUCT_NAME(tag, BRANCHFREE_POSTFIX)
 
-static LIBDIVIDE_INLINE int16_t libdivide_s16_branchfree_do(
-    int16_t numer, const struct libdivide_s16_branchfree_t *denom);
-static LIBDIVIDE_INLINE uint16_t libdivide_u16_branchfree_do(
-    uint16_t numer, const struct libdivide_u16_branchfree_t *denom);
-static LIBDIVIDE_INLINE int32_t libdivide_s32_branchfree_do(
-    int32_t numer, const struct libdivide_s32_branchfree_t *denom);
-static LIBDIVIDE_INLINE uint32_t libdivide_u32_branchfree_do(
-    uint32_t numer, const struct libdivide_u32_branchfree_t *denom);
-static LIBDIVIDE_INLINE int64_t libdivide_s64_branchfree_do(
-    int64_t numer, const struct libdivide_s64_branchfree_t *denom);
-static LIBDIVIDE_INLINE uint64_t libdivide_u64_branchfree_do(
-    uint64_t numer, const struct libdivide_u64_branchfree_t *denom);
+// pack divider structs to prevent compilers from padding.
+// This reduces memory usage by up to 43% when using a large
+// array of libdivide dividers and improves performance
+// by up to 10% because of reduced memory bandwidth.
+#define DEFINE_STRUCTS(tag, type) \
+    _Pragma("pack(push, 1)") \
+    struct STRUCT_NAME(tag) { \
+        type magic; \
+        uint8_t more; \
+    }; \
+    struct STRUCT_BRANCHFREE_NAME(tag) { \
+        type magic; \
+        uint8_t more; \
+    }; \
+    _Pragma("pack(pop)")
 
-static LIBDIVIDE_INLINE int16_t libdivide_s16_recover(const struct libdivide_s16_t *denom);
-static LIBDIVIDE_INLINE uint16_t libdivide_u16_recover(const struct libdivide_u16_t *denom);
-static LIBDIVIDE_INLINE int32_t libdivide_s32_recover(const struct libdivide_s32_t *denom);
-static LIBDIVIDE_INLINE uint32_t libdivide_u32_recover(const struct libdivide_u32_t *denom);
-static LIBDIVIDE_INLINE int64_t libdivide_s64_recover(const struct libdivide_s64_t *denom);
-static LIBDIVIDE_INLINE uint64_t libdivide_u64_recover(const struct libdivide_u64_t *denom);
+#define FUNC_NAME_BUILDER(tag, postfix) CONCAT(libdivide_, CONCAT(tag, postfix))
 
-static LIBDIVIDE_INLINE int16_t libdivide_s16_branchfree_recover(
-    const struct libdivide_s16_branchfree_t *denom);
-static LIBDIVIDE_INLINE uint16_t libdivide_u16_branchfree_recover(
-    const struct libdivide_u16_branchfree_t *denom);
-static LIBDIVIDE_INLINE int32_t libdivide_s32_branchfree_recover(
-    const struct libdivide_s32_branchfree_t *denom);
-static LIBDIVIDE_INLINE uint32_t libdivide_u32_branchfree_recover(
-    const struct libdivide_u32_branchfree_t *denom);
-static LIBDIVIDE_INLINE int64_t libdivide_s64_branchfree_recover(
-    const struct libdivide_s64_branchfree_t *denom);
-static LIBDIVIDE_INLINE uint64_t libdivide_u64_branchfree_recover(
-    const struct libdivide_u64_branchfree_t *denom);
+// These need to be implemented by maintiners
+#define CORE_FUNCTION_DECLARATIONS(tag, type) \
+    static LIBDIVIDE_INLINE struct STRUCT_NAME(tag) FUNC_NAME_BUILDER(tag, _gen)(type d); \
+    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _do_raw)(type numer, type magic, uint8_t more); \
+    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _recover_raw)(type magic, uint8_t more); \
+    static LIBDIVIDE_INLINE struct STRUCT_BRANCHFREE_NAME(tag) FUNC_NAME_BUILDER(tag, _branchfree_gen)(type d); \
+    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _branchfree_do_raw)(type numer, type magic, uint8_t more); \
+    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _branchfree_recover_raw)(type magic, uint8_t more); \
+
+// Both the declaration of these AND the implementation of these can be automated
+// See WRAPPER_FUNCTION_IMPLEMENTATIONS
+#define WRAPPER_FUNCTION_DECLARATIONS(tag, type) \
+    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _do)(type numer, const struct STRUCT_NAME(tag) *denom); \
+    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _recover)(const struct STRUCT_NAME(tag) *denom); \
+    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _branchfree_do)(type numer, const struct STRUCT_BRANCHFREE_NAME(tag) *denom); \
+    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _branchfree_recover)(const struct STRUCT_BRANCHFREE_NAME(tag) *denom); \
+
+#define DECLARE_TYPE(tag, type) \
+    DEFINE_STRUCTS(tag, type) \
+    CORE_FUNCTION_DECLARATIONS(tag, type) \
+    WRAPPER_FUNCTION_DECLARATIONS(tag, type)
+
+DECLARE_TYPE(s16, int16_t)
+DECLARE_TYPE(u16, uint16_t)
+DECLARE_TYPE(s32, int32_t)
+DECLARE_TYPE(u32, uint32_t)
+DECLARE_TYPE(s64, int64_t)
+DECLARE_TYPE(u64, uint64_t)
 
 //////// Internal Utility Functions
 
@@ -643,6 +611,20 @@ static LIBDIVIDE_INLINE uint64_t libdivide_128_div_128_to_64(
 #endif
 }
 
+#define WRAPPER_FUNCTION_IMPLEMENTATIONS(tag, type) \
+    type FUNC_NAME_BUILDER(tag, _do)(type numer, const struct STRUCT_NAME(tag) *denom) {\
+        return FUNC_NAME_BUILDER(tag, _do_raw)(numer, denom->magic, denom->more); \
+    } \
+    type FUNC_NAME_BUILDER(tag, _branchfree_do)(type numer, const struct STRUCT_BRANCHFREE_NAME(tag) *denom) {\
+        return FUNC_NAME_BUILDER(tag, _branchfree_do_raw)(numer, denom->magic, denom->more); \
+    } \
+    type FUNC_NAME_BUILDER(tag, _recover)(const struct STRUCT_NAME(tag) *denom) {\
+        return FUNC_NAME_BUILDER(tag, _recover_raw)(denom->magic, denom->more); \
+    } \
+    type FUNC_NAME_BUILDER(tag, _branchfree_recover)(const struct STRUCT_BRANCHFREE_NAME(tag) *denom) {\
+        return FUNC_NAME_BUILDER(tag, _branchfree_recover_raw)(denom->magic, denom->more); \
+    }
+
 ////////// UINT16
 
 static LIBDIVIDE_INLINE struct libdivide_u16_t libdivide_internal_u16_gen(
@@ -729,22 +711,16 @@ uint16_t libdivide_u16_do_raw(uint16_t numer, uint16_t magic, uint8_t more) {
     }
 }
 
-uint16_t libdivide_u16_do(uint16_t numer, const struct libdivide_u16_t *denom) {
-    return libdivide_u16_do_raw(numer, denom->magic, denom->more);
-}
-
-uint16_t libdivide_u16_branchfree_do(
-    uint16_t numer, const struct libdivide_u16_branchfree_t *denom) {
-    uint16_t q = libdivide_mullhi_u16(denom->magic, numer);
+uint16_t libdivide_u16_branchfree_do_raw(uint16_t numer, uint16_t magic, uint8_t more) {
+    uint16_t q = libdivide_mullhi_u16(magic, numer);
     uint16_t t = ((numer - q) >> 1) + q;
-    return t >> denom->more;
+    return t >> more;
 }
 
-uint16_t libdivide_u16_recover(const struct libdivide_u16_t *denom) {
-    uint8_t more = denom->more;
+uint16_t libdivide_u16_recover_raw(uint16_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_16_SHIFT_MASK;
 
-    if (!denom->magic) {
+    if (!magic) {
         return (uint16_t)1 << shift;
     } else if (!(more & LIBDIVIDE_ADD_MARKER)) {
         // We compute q = n/d = n*m / 2^(16 + shift)
@@ -754,7 +730,7 @@ uint16_t libdivide_u16_recover(const struct libdivide_u16_t *denom) {
         // so we can just add 1 to the floor
         uint16_t hi_dividend = (uint16_t)1 << shift;
         uint16_t rem_ignored;
-        return 1 + libdivide_32_div_16_to_16(hi_dividend, 0, denom->magic, &rem_ignored);
+        return 1 + libdivide_32_div_16_to_16(hi_dividend, 0, magic, &rem_ignored);
     } else {
         // Here we wish to compute d = 2^(16+shift+1)/(m+2^16).
         // Notice (m + 2^16) is a 17 bit number. Use 32 bit division for now
@@ -762,7 +738,7 @@ uint16_t libdivide_u16_recover(const struct libdivide_u16_t *denom) {
         // overflow. So we have to compute it as 2^(16+shift)/(m+2^16), and
         // then double the quotient and remainder.
         uint32_t half_n = (uint32_t)1 << (16 + shift);
-        uint32_t d = ((uint32_t)1 << 16) | denom->magic;
+        uint32_t d = ((uint32_t)1 << 16) | magic;
         // Note that the quotient is guaranteed <= 16 bits, but the remainder
         // may need 17!
         uint16_t half_q = (uint16_t)(half_n / d);
@@ -778,11 +754,10 @@ uint16_t libdivide_u16_recover(const struct libdivide_u16_t *denom) {
     }
 }
 
-uint16_t libdivide_u16_branchfree_recover(const struct libdivide_u16_branchfree_t *denom) {
-    uint8_t more = denom->more;
+uint16_t libdivide_u16_branchfree_recover_raw(uint16_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_16_SHIFT_MASK;
 
-    if (!denom->magic) {
+    if (!magic) {
         return (uint16_t)1 << (shift + 1);
     } else {
         // Here we wish to compute d = 2^(16+shift+1)/(m+2^16).
@@ -791,7 +766,7 @@ uint16_t libdivide_u16_branchfree_recover(const struct libdivide_u16_branchfree_
         // overflow. So we have to compute it as 2^(16+shift)/(m+2^16), and
         // then double the quotient and remainder.
         uint32_t half_n = (uint32_t)1 << (16 + shift);
-        uint32_t d = ((uint32_t)1 << 16) | denom->magic;
+        uint32_t d = ((uint32_t)1 << 16) | magic;
         // Note that the quotient is guaranteed <= 16 bits, but the remainder
         // may need 17!
         uint16_t half_q = (uint16_t)(half_n / d);
@@ -806,6 +781,9 @@ uint16_t libdivide_u16_branchfree_recover(const struct libdivide_u16_branchfree_
         return full_q + 1;
     }
 }
+
+WRAPPER_FUNCTION_IMPLEMENTATIONS(u16, uint16_t)
+
 
 ////////// UINT32
 
@@ -874,12 +852,11 @@ struct libdivide_u32_branchfree_t libdivide_u32_branchfree_gen(uint32_t d) {
     return ret;
 }
 
-uint32_t libdivide_u32_do(uint32_t numer, const struct libdivide_u32_t *denom) {
-    uint8_t more = denom->more;
-    if (!denom->magic) {
+uint32_t libdivide_u32_do_raw(uint32_t numer, uint32_t magic, uint8_t more) {
+    if (!magic) {
         return numer >> more;
     } else {
-        uint32_t q = libdivide_mullhi_u32(denom->magic, numer);
+        uint32_t q = libdivide_mullhi_u32(magic, numer);
         if (more & LIBDIVIDE_ADD_MARKER) {
             uint32_t t = ((numer - q) >> 1) + q;
             return t >> (more & LIBDIVIDE_32_SHIFT_MASK);
@@ -891,18 +868,16 @@ uint32_t libdivide_u32_do(uint32_t numer, const struct libdivide_u32_t *denom) {
     }
 }
 
-uint32_t libdivide_u32_branchfree_do(
-    uint32_t numer, const struct libdivide_u32_branchfree_t *denom) {
-    uint32_t q = libdivide_mullhi_u32(denom->magic, numer);
+uint32_t libdivide_u32_branchfree_do_raw(uint32_t numer, uint32_t magic, uint8_t more) {
+    uint32_t q = libdivide_mullhi_u32(magic, numer);
     uint32_t t = ((numer - q) >> 1) + q;
-    return t >> denom->more;
+    return t >> more;
 }
 
-uint32_t libdivide_u32_recover(const struct libdivide_u32_t *denom) {
-    uint8_t more = denom->more;
+uint32_t libdivide_u32_recover_raw(uint32_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_32_SHIFT_MASK;
 
-    if (!denom->magic) {
+    if (!magic) {
         return (uint32_t)1 << shift;
     } else if (!(more & LIBDIVIDE_ADD_MARKER)) {
         // We compute q = n/d = n*m / 2^(32 + shift)
@@ -912,7 +887,7 @@ uint32_t libdivide_u32_recover(const struct libdivide_u32_t *denom) {
         // so we can just add 1 to the floor
         uint32_t hi_dividend = (uint32_t)1 << shift;
         uint32_t rem_ignored;
-        return 1 + libdivide_64_div_32_to_32(hi_dividend, 0, denom->magic, &rem_ignored);
+        return 1 + libdivide_64_div_32_to_32(hi_dividend, 0, magic, &rem_ignored);
     } else {
         // Here we wish to compute d = 2^(32+shift+1)/(m+2^32).
         // Notice (m + 2^32) is a 33 bit number. Use 64 bit division for now
@@ -920,7 +895,7 @@ uint32_t libdivide_u32_recover(const struct libdivide_u32_t *denom) {
         // overflow. So we have to compute it as 2^(32+shift)/(m+2^32), and
         // then double the quotient and remainder.
         uint64_t half_n = (uint64_t)1 << (32 + shift);
-        uint64_t d = ((uint64_t)1 << 32) | denom->magic;
+        uint64_t d = ((uint64_t)1 << 32) | magic;
         // Note that the quotient is guaranteed <= 32 bits, but the remainder
         // may need 33!
         uint32_t half_q = (uint32_t)(half_n / d);
@@ -936,11 +911,10 @@ uint32_t libdivide_u32_recover(const struct libdivide_u32_t *denom) {
     }
 }
 
-uint32_t libdivide_u32_branchfree_recover(const struct libdivide_u32_branchfree_t *denom) {
-    uint8_t more = denom->more;
+uint32_t libdivide_u32_branchfree_recover_raw(uint32_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_32_SHIFT_MASK;
 
-    if (!denom->magic) {
+    if (!magic) {
         return (uint32_t)1 << (shift + 1);
     } else {
         // Here we wish to compute d = 2^(32+shift+1)/(m+2^32).
@@ -949,7 +923,7 @@ uint32_t libdivide_u32_branchfree_recover(const struct libdivide_u32_branchfree_
         // overflow. So we have to compute it as 2^(32+shift)/(m+2^32), and
         // then double the quotient and remainder.
         uint64_t half_n = (uint64_t)1 << (32 + shift);
-        uint64_t d = ((uint64_t)1 << 32) | denom->magic;
+        uint64_t d = ((uint64_t)1 << 32) | magic;
         // Note that the quotient is guaranteed <= 32 bits, but the remainder
         // may need 33!
         uint32_t half_q = (uint32_t)(half_n / d);
@@ -964,6 +938,8 @@ uint32_t libdivide_u32_branchfree_recover(const struct libdivide_u32_branchfree_
         return full_q + 1;
     }
 }
+
+WRAPPER_FUNCTION_IMPLEMENTATIONS(u32, uint32_t)
 
 /////////// UINT64
 
@@ -1034,12 +1010,11 @@ struct libdivide_u64_branchfree_t libdivide_u64_branchfree_gen(uint64_t d) {
     return ret;
 }
 
-uint64_t libdivide_u64_do(uint64_t numer, const struct libdivide_u64_t *denom) {
-    uint8_t more = denom->more;
-    if (!denom->magic) {
+uint64_t libdivide_u64_do_raw(uint64_t numer, uint64_t magic, uint8_t more) {
+    if (!magic) {
         return numer >> more;
     } else {
-        uint64_t q = libdivide_mullhi_u64(denom->magic, numer);
+        uint64_t q = libdivide_mullhi_u64(magic, numer);
         if (more & LIBDIVIDE_ADD_MARKER) {
             uint64_t t = ((numer - q) >> 1) + q;
             return t >> (more & LIBDIVIDE_64_SHIFT_MASK);
@@ -1051,18 +1026,17 @@ uint64_t libdivide_u64_do(uint64_t numer, const struct libdivide_u64_t *denom) {
     }
 }
 
-uint64_t libdivide_u64_branchfree_do(
-    uint64_t numer, const struct libdivide_u64_branchfree_t *denom) {
-    uint64_t q = libdivide_mullhi_u64(denom->magic, numer);
+uint64_t libdivide_u64_branchfree_do_raw(
+    uint64_t numer, uint64_t magic, uint8_t more) {
+    uint64_t q = libdivide_mullhi_u64(magic, numer);
     uint64_t t = ((numer - q) >> 1) + q;
-    return t >> denom->more;
+    return t >> more;
 }
 
-uint64_t libdivide_u64_recover(const struct libdivide_u64_t *denom) {
-    uint8_t more = denom->more;
+uint64_t libdivide_u64_recover_raw(uint64_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_64_SHIFT_MASK;
 
-    if (!denom->magic) {
+    if (!magic) {
         return (uint64_t)1 << shift;
     } else if (!(more & LIBDIVIDE_ADD_MARKER)) {
         // We compute q = n/d = n*m / 2^(64 + shift)
@@ -1072,7 +1046,7 @@ uint64_t libdivide_u64_recover(const struct libdivide_u64_t *denom) {
         // so we can just add 1 to the floor
         uint64_t hi_dividend = (uint64_t)1 << shift;
         uint64_t rem_ignored;
-        return 1 + libdivide_128_div_64_to_64(hi_dividend, 0, denom->magic, &rem_ignored);
+        return 1 + libdivide_128_div_64_to_64(hi_dividend, 0, magic, &rem_ignored);
     } else {
         // Here we wish to compute d = 2^(64+shift+1)/(m+2^64).
         // Notice (m + 2^64) is a 65 bit number. This gets hairy. See
@@ -1084,7 +1058,7 @@ uint64_t libdivide_u64_recover(const struct libdivide_u64_t *denom) {
         // Compute the hi half of half_n. Low half is 0.
         uint64_t half_n_hi = (uint64_t)1 << shift, half_n_lo = 0;
         // d is a 65 bit value. The high bit is always set to 1.
-        const uint64_t d_hi = 1, d_lo = denom->magic;
+        const uint64_t d_hi = 1, d_lo = magic;
         // Note that the quotient is guaranteed <= 64 bits,
         // but the remainder may need 65!
         uint64_t r_hi, r_lo;
@@ -1102,11 +1076,10 @@ uint64_t libdivide_u64_recover(const struct libdivide_u64_t *denom) {
     }
 }
 
-uint64_t libdivide_u64_branchfree_recover(const struct libdivide_u64_branchfree_t *denom) {
-    uint8_t more = denom->more;
+uint64_t libdivide_u64_branchfree_recover_raw(uint64_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_64_SHIFT_MASK;
 
-    if (!denom->magic) {
+    if (!magic) {
         return (uint64_t)1 << (shift + 1);
     } else {
         // Here we wish to compute d = 2^(64+shift+1)/(m+2^64).
@@ -1119,7 +1092,7 @@ uint64_t libdivide_u64_branchfree_recover(const struct libdivide_u64_branchfree_
         // Compute the hi half of half_n. Low half is 0.
         uint64_t half_n_hi = (uint64_t)1 << shift, half_n_lo = 0;
         // d is a 65 bit value. The high bit is always set to 1.
-        const uint64_t d_hi = 1, d_lo = denom->magic;
+        const uint64_t d_hi = 1, d_lo = magic;
         // Note that the quotient is guaranteed <= 64 bits,
         // but the remainder may need 65!
         uint64_t r_hi, r_lo;
@@ -1136,6 +1109,8 @@ uint64_t libdivide_u64_branchfree_recover(const struct libdivide_u64_branchfree_
         return full_q + 1;
     }
 }
+
+WRAPPER_FUNCTION_IMPLEMENTATIONS(u64, uint64_t)
 
 /////////// SINT16
 
@@ -1245,16 +1220,10 @@ int16_t libdivide_s16_do_raw(int16_t numer, int16_t magic, uint8_t more) {
     }
 }
 
-int16_t libdivide_s16_do(int16_t numer, const struct libdivide_s16_t *denom) {
-    return libdivide_s16_do_raw(numer, denom->magic, denom->more);
-}
-
-int16_t libdivide_s16_branchfree_do(int16_t numer, const struct libdivide_s16_branchfree_t *denom) {
-    uint8_t more = denom->more;
+int16_t libdivide_s16_branchfree_do_raw(int16_t numer, int16_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_16_SHIFT_MASK;
     // must be arithmetic shift and then sign extend
     int16_t sign = (int8_t)more >> 7;
-    int16_t magic = denom->magic;
     int16_t q = libdivide_mullhi_s16(magic, numer);
     q += numer;
 
@@ -1273,10 +1242,9 @@ int16_t libdivide_s16_branchfree_do(int16_t numer, const struct libdivide_s16_br
     return q;
 }
 
-int16_t libdivide_s16_recover(const struct libdivide_s16_t *denom) {
-    uint8_t more = denom->more;
+int16_t libdivide_s16_recover_raw(int16_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_16_SHIFT_MASK;
-    if (!denom->magic) {
+    if (!magic) {
         uint16_t absD = (uint16_t)1 << shift;
         if (more & LIBDIVIDE_NEGATIVE_DIVISOR) {
             absD = -absD;
@@ -1291,15 +1259,15 @@ int16_t libdivide_s16_recover(const struct libdivide_s16_t *denom) {
         // the magic number's sign is opposite that of the divisor.
         // We want to compute the positive magic number.
         int negative_divisor = (more & LIBDIVIDE_NEGATIVE_DIVISOR);
-        int magic_was_negated = (more & LIBDIVIDE_ADD_MARKER) ? denom->magic > 0 : denom->magic < 0;
+        int magic_was_negated = (more & LIBDIVIDE_ADD_MARKER) ? magic > 0 : magic < 0;
 
         // Handle the power of 2 case (including branchfree)
-        if (denom->magic == 0) {
+        if (magic == 0) {
             int16_t result = (uint16_t)1 << shift;
             return negative_divisor ? -result : result;
         }
 
-        uint16_t d = (uint16_t)(magic_was_negated ? -denom->magic : denom->magic);
+        uint16_t d = (uint16_t)(magic_was_negated ? -magic : magic);
         uint32_t n = (uint32_t)1 << (16 + shift);  // this shift cannot exceed 30
         uint16_t q = (uint16_t)(n / d);
         int16_t result = (int16_t)q;
@@ -1308,9 +1276,11 @@ int16_t libdivide_s16_recover(const struct libdivide_s16_t *denom) {
     }
 }
 
-int16_t libdivide_s16_branchfree_recover(const struct libdivide_s16_branchfree_t *denom) {
-    return libdivide_s16_recover((const struct libdivide_s16_t *)denom);
+int16_t libdivide_s16_branchfree_recover_raw(int16_t magic, uint8_t more) {
+    return libdivide_s16_recover_raw(magic, more);
 }
+
+WRAPPER_FUNCTION_IMPLEMENTATIONS(s16, int16_t)
 
 /////////// SINT32
 
@@ -1390,11 +1360,10 @@ struct libdivide_s32_branchfree_t libdivide_s32_branchfree_gen(int32_t d) {
     return result;
 }
 
-int32_t libdivide_s32_do(int32_t numer, const struct libdivide_s32_t *denom) {
-    uint8_t more = denom->more;
+int32_t libdivide_s32_do_raw(int32_t numer, int32_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_32_SHIFT_MASK;
 
-    if (!denom->magic) {
+    if (!magic) {
         uint32_t sign = (int8_t)more >> 7;
         uint32_t mask = ((uint32_t)1 << shift) - 1;
         uint32_t uq = numer + ((numer >> 31) & mask);
@@ -1403,7 +1372,7 @@ int32_t libdivide_s32_do(int32_t numer, const struct libdivide_s32_t *denom) {
         q = (q ^ sign) - sign;
         return q;
     } else {
-        uint32_t uq = (uint32_t)libdivide_mullhi_s32(denom->magic, numer);
+        uint32_t uq = (uint32_t)libdivide_mullhi_s32(magic, numer);
         if (more & LIBDIVIDE_ADD_MARKER) {
             // must be arithmetic shift and then sign extend
             int32_t sign = (int8_t)more >> 7;
@@ -1418,12 +1387,10 @@ int32_t libdivide_s32_do(int32_t numer, const struct libdivide_s32_t *denom) {
     }
 }
 
-int32_t libdivide_s32_branchfree_do(int32_t numer, const struct libdivide_s32_branchfree_t *denom) {
-    uint8_t more = denom->more;
+int32_t libdivide_s32_branchfree_do_raw(int32_t numer, int32_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_32_SHIFT_MASK;
     // must be arithmetic shift and then sign extend
     int32_t sign = (int8_t)more >> 7;
-    int32_t magic = denom->magic;
     int32_t q = libdivide_mullhi_s32(magic, numer);
     q += numer;
 
@@ -1442,10 +1409,9 @@ int32_t libdivide_s32_branchfree_do(int32_t numer, const struct libdivide_s32_br
     return q;
 }
 
-int32_t libdivide_s32_recover(const struct libdivide_s32_t *denom) {
-    uint8_t more = denom->more;
+int32_t libdivide_s32_recover_raw(int32_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_32_SHIFT_MASK;
-    if (!denom->magic) {
+    if (!magic) {
         uint32_t absD = (uint32_t)1 << shift;
         if (more & LIBDIVIDE_NEGATIVE_DIVISOR) {
             absD = -absD;
@@ -1460,15 +1426,15 @@ int32_t libdivide_s32_recover(const struct libdivide_s32_t *denom) {
         // the magic number's sign is opposite that of the divisor.
         // We want to compute the positive magic number.
         int negative_divisor = (more & LIBDIVIDE_NEGATIVE_DIVISOR);
-        int magic_was_negated = (more & LIBDIVIDE_ADD_MARKER) ? denom->magic > 0 : denom->magic < 0;
+        int magic_was_negated = (more & LIBDIVIDE_ADD_MARKER) ? magic > 0 : magic < 0;
 
         // Handle the power of 2 case (including branchfree)
-        if (denom->magic == 0) {
+        if (magic == 0) {
             int32_t result = (uint32_t)1 << shift;
             return negative_divisor ? -result : result;
         }
 
-        uint32_t d = (uint32_t)(magic_was_negated ? -denom->magic : denom->magic);
+        uint32_t d = (uint32_t)(magic_was_negated ? -magic : magic);
         uint64_t n = (uint64_t)1 << (32 + shift);  // this shift cannot exceed 30
         uint32_t q = (uint32_t)(n / d);
         int32_t result = (int32_t)q;
@@ -1477,9 +1443,11 @@ int32_t libdivide_s32_recover(const struct libdivide_s32_t *denom) {
     }
 }
 
-int32_t libdivide_s32_branchfree_recover(const struct libdivide_s32_branchfree_t *denom) {
-    return libdivide_s32_recover((const struct libdivide_s32_t *)denom);
+int32_t libdivide_s32_branchfree_recover_raw(int32_t magic, uint8_t more) {
+    return libdivide_s32_recover_raw(magic, more);
 }
+
+WRAPPER_FUNCTION_IMPLEMENTATIONS(s32, int32_t)
 
 ///////////// SINT64
 
@@ -1559,11 +1527,10 @@ struct libdivide_s64_branchfree_t libdivide_s64_branchfree_gen(int64_t d) {
     return ret;
 }
 
-int64_t libdivide_s64_do(int64_t numer, const struct libdivide_s64_t *denom) {
-    uint8_t more = denom->more;
+int64_t libdivide_s64_do_raw(int64_t numer, int64_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_64_SHIFT_MASK;
 
-    if (!denom->magic) {  // shift path
+    if (!magic) {  // shift path
         uint64_t mask = ((uint64_t)1 << shift) - 1;
         uint64_t uq = numer + ((numer >> 63) & mask);
         int64_t q = (int64_t)uq;
@@ -1573,7 +1540,7 @@ int64_t libdivide_s64_do(int64_t numer, const struct libdivide_s64_t *denom) {
         q = (q ^ sign) - sign;
         return q;
     } else {
-        uint64_t uq = (uint64_t)libdivide_mullhi_s64(denom->magic, numer);
+        uint64_t uq = (uint64_t)libdivide_mullhi_s64(magic, numer);
         if (more & LIBDIVIDE_ADD_MARKER) {
             // must be arithmetic shift and then sign extend
             int64_t sign = (int8_t)more >> 7;
@@ -1588,12 +1555,10 @@ int64_t libdivide_s64_do(int64_t numer, const struct libdivide_s64_t *denom) {
     }
 }
 
-int64_t libdivide_s64_branchfree_do(int64_t numer, const struct libdivide_s64_branchfree_t *denom) {
-    uint8_t more = denom->more;
+int64_t libdivide_s64_branchfree_do_raw(int64_t numer, int64_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_64_SHIFT_MASK;
     // must be arithmetic shift and then sign extend
     int64_t sign = (int8_t)more >> 7;
-    int64_t magic = denom->magic;
     int64_t q = libdivide_mullhi_s64(magic, numer);
     q += numer;
 
@@ -1612,10 +1577,9 @@ int64_t libdivide_s64_branchfree_do(int64_t numer, const struct libdivide_s64_br
     return q;
 }
 
-int64_t libdivide_s64_recover(const struct libdivide_s64_t *denom) {
-    uint8_t more = denom->more;
+int64_t libdivide_s64_recover_raw(int64_t magic, uint8_t more) {
     uint8_t shift = more & LIBDIVIDE_64_SHIFT_MASK;
-    if (denom->magic == 0) {  // shift path
+    if (magic == 0) {  // shift path
         uint64_t absD = (uint64_t)1 << shift;
         if (more & LIBDIVIDE_NEGATIVE_DIVISOR) {
             absD = -absD;
@@ -1624,9 +1588,9 @@ int64_t libdivide_s64_recover(const struct libdivide_s64_t *denom) {
     } else {
         // Unsigned math is much easier
         int negative_divisor = (more & LIBDIVIDE_NEGATIVE_DIVISOR);
-        int magic_was_negated = (more & LIBDIVIDE_ADD_MARKER) ? denom->magic > 0 : denom->magic < 0;
+        int magic_was_negated = (more & LIBDIVIDE_ADD_MARKER) ? magic > 0 : magic < 0;
 
-        uint64_t d = (uint64_t)(magic_was_negated ? -denom->magic : denom->magic);
+        uint64_t d = (uint64_t)(magic_was_negated ? -magic : magic);
         uint64_t n_hi = (uint64_t)1 << shift, n_lo = 0;
         uint64_t rem_ignored;
         uint64_t q = libdivide_128_div_64_to_64(n_hi, n_lo, d, &rem_ignored);
@@ -1638,9 +1602,11 @@ int64_t libdivide_s64_recover(const struct libdivide_s64_t *denom) {
     }
 }
 
-int64_t libdivide_s64_branchfree_recover(const struct libdivide_s64_branchfree_t *denom) {
-    return libdivide_s64_recover((const struct libdivide_s64_t *)denom);
+int64_t libdivide_s64_branchfree_recover_raw(int64_t magic, uint8_t more) {
+    return libdivide_s64_recover_raw(magic, more);
 }
+
+WRAPPER_FUNCTION_IMPLEMENTATIONS(s64, int64_t)
 
 // Simplest possible vector type division: treat the vector type as an array
 // of underlying native type.

--- a/libdivide.h
+++ b/libdivide.h
@@ -183,6 +183,8 @@ enum {
     LIBDIVIDE_NEGATIVE_DIVISOR = 0x80
 };
 
+#undef _LD_CONCAT
+#undef LD_CONCAT
 #define _LD_CONCAT(x,y) x ## y
 #define LD_CONCAT(x,y) _LD_CONCAT(x,y)
 
@@ -357,7 +359,7 @@ static LIBDIVIDE_INLINE int64_t libdivide_mullhi_s64(int64_t x, int64_t y) {
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE uint8_t libdivide_count_leading_zeros16_software(uint16_t val) {
     if (val == 0) return 16;
     uint8_t result = 4;
-    uint16_t hi = 0xFU << 12;
+    uint16_t hi = (uint16_t)0xFU << 12U;
     while ((val & hi) == 0) {
         hi >>= 4;
         result += 4U;
@@ -391,7 +393,7 @@ static LIBDIVIDE_INLINE uint8_t libdivide_count_leading_zeros16(uint16_t val) {
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE uint8_t libdivide_count_leading_zeros32_software(uint32_t val) {
     if (val == 0) return 32U;
     uint8_t result = 8;
-    uint32_t hi = 0xFFU << 24U;
+    uint32_t hi = (uint32_t)0xFFU << 24U;
     while ((val & hi) == 0) {
         hi >>= 8;
         result += 8U;
@@ -423,7 +425,7 @@ static LIBDIVIDE_INLINE uint8_t libdivide_count_leading_zeros32(uint32_t val) {
 
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE uint8_t libdivide_count_leading_zeros64_software(uint64_t val) {
-    uint32_t hi = val >> 32;
+    uint32_t hi = val >> 32U;
     uint32_t lo = val & 0xFFFFFFFF;
     if (hi != 0) return libdivide_count_leading_zeros32_software(hi);
     return 32U + libdivide_count_leading_zeros32_software(lo);
@@ -470,7 +472,7 @@ struct libdivide_64_div_32_result_t {
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_64_div_32_result_t libdivide_64_div_32_to_32_software(
     uint32_t u1, uint32_t u0, uint32_t v) {
-    uint64_t n = ((uint64_t)u1 << 32) | u0;
+    uint64_t n = ((uint64_t)u1 << 32U) | u0;
     struct libdivide_64_div_32_result_t result = { 0U, 0U };
     result.quot = (uint32_t)(n / v);
     result.rem = (uint32_t)(n - result.quot * (uint64_t)v);\
@@ -1316,10 +1318,7 @@ WRAPPER_FUNCTION_IMPLEMENTATIONS(u64, uint64_t)
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE uint16_t libdivide_internal_s16_abs(int16_t d) {
     uint16_t ud = (uint16_t)d;
-#pragma warning( push )
-#pragma warning( disable : 4146 )
     return (d < 0) ? -ud : ud;    
-#pragma warning( pop )
 }
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_s16_t libdivide_internal_s16_gen_gen(
@@ -1518,10 +1517,7 @@ WRAPPER_FUNCTION_IMPLEMENTATIONS(s16, int16_t)
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE uint32_t libdivide_internal_s32_abs(int32_t d) {
     uint32_t ud = (uint32_t)d;
-#pragma warning( push )
-#pragma warning( disable : 4146 )
     return (d < 0) ? -ud : ud;
-#pragma warning( pop )
 }
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_s32_t libdivide_internal_s32_gen_gen(
@@ -1718,10 +1714,7 @@ WRAPPER_FUNCTION_IMPLEMENTATIONS(s32, int32_t)
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE uint64_t libdivide_internal_s64_abs(int64_t d) {
     uint64_t ud = (uint64_t)d;
-#pragma warning( push )
-#pragma warning( disable : 4146 )
     return (d < 0) ? -ud : ud;    
-#pragma warning( pop )    
 }
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_s64_t libdivide_internal_s64_gen_gen(

--- a/libdivide.h
+++ b/libdivide.h
@@ -195,8 +195,21 @@ enum {
     static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _branchfree_recover_raw)(type magic, uint8_t more); \
 
 // Both the declaration of these AND the implementation of these can be automated
-// See WRAPPER_FUNCTION_IMPLEMENTATIONS
-#define WRAPPER_FUNCTION_DECLARATIONS(tag, type) \
+// See WRAPPER_FUNCTION_IMPLEMENTATIONS_CPP
+#if defined(__cplusplus)
+#define WRAPPER_FUNCTION_DECLARATIONS_CPP(tag, type) \
+    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _do)(type numer, const STRUCT_NAME(tag) &denom); \
+    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _branchfree_do)(type numer, const STRUCT_BRANCHFREE_NAME(tag) &denom); \
+    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _recover)(const STRUCT_NAME(tag) &denom); \
+    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _branchfree_recover)(const STRUCT_BRANCHFREE_NAME(tag) &denom);
+#else
+#define WRAPPER_FUNCTION_DECLARATIONS_CPP(tag, type)
+#endif
+
+
+// Both the declaration of these AND the implementation of these can be automated
+// See WRAPPER_FUNCTION_IMPLEMENTATIONS_CORE
+#define WRAPPER_FUNCTION_DECLARATIONS_CORE(tag, type) \
     static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _do)(type numer, const struct STRUCT_NAME(tag) *denom); \
     static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _recover)(const struct STRUCT_NAME(tag) *denom); \
     static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _branchfree_do)(type numer, const struct STRUCT_BRANCHFREE_NAME(tag) *denom); \
@@ -205,7 +218,8 @@ enum {
 #define DECLARE_TYPE(tag, type) \
     DEFINE_STRUCTS(tag, type) \
     CORE_FUNCTION_DECLARATIONS(tag, type) \
-    WRAPPER_FUNCTION_DECLARATIONS(tag, type)
+    WRAPPER_FUNCTION_DECLARATIONS_CORE(tag, type) \
+    WRAPPER_FUNCTION_DECLARATIONS_CPP(tag, type)
 
 DECLARE_TYPE(s16, int16_t)
 DECLARE_TYPE(u16, uint16_t)
@@ -611,7 +625,7 @@ static LIBDIVIDE_INLINE uint64_t libdivide_128_div_128_to_64(
 #endif
 }
 
-#define WRAPPER_FUNCTION_IMPLEMENTATIONS(tag, type) \
+#define WRAPPER_FUNCTION_IMPLEMENTATIONS_CORE(tag, type) \
     type FUNC_NAME_BUILDER(tag, _do)(type numer, const struct STRUCT_NAME(tag) *denom) {\
         return FUNC_NAME_BUILDER(tag, _do_raw)(numer, denom->magic, denom->more); \
     } \
@@ -624,6 +638,29 @@ static LIBDIVIDE_INLINE uint64_t libdivide_128_div_128_to_64(
     type FUNC_NAME_BUILDER(tag, _branchfree_recover)(const struct STRUCT_BRANCHFREE_NAME(tag) *denom) {\
         return FUNC_NAME_BUILDER(tag, _branchfree_recover_raw)(denom->magic, denom->more); \
     }
+
+
+#if defined(__cplusplus)
+#define WRAPPER_FUNCTION_IMPLEMENTATIONS_CPP(tag, type) \
+    type FUNC_NAME_BUILDER(tag, _do)(type numer, const STRUCT_NAME(tag) &denom) {\
+        return FUNC_NAME_BUILDER(tag, _do_raw)(numer, denom.magic, denom.more); \
+    } \
+    type FUNC_NAME_BUILDER(tag, _branchfree_do)(type numer, const STRUCT_BRANCHFREE_NAME(tag) &denom) {\
+        return FUNC_NAME_BUILDER(tag, _branchfree_do_raw)(numer, denom.magic, denom.more); \
+    } \
+    type FUNC_NAME_BUILDER(tag, _recover)(const STRUCT_NAME(tag) &denom) {\
+        return FUNC_NAME_BUILDER(tag, _recover_raw)(denom.magic, denom.more); \
+    } \
+    type FUNC_NAME_BUILDER(tag, _branchfree_recover)(const STRUCT_BRANCHFREE_NAME(tag) &denom) {\
+        return FUNC_NAME_BUILDER(tag, _branchfree_recover_raw)(denom.magic, denom.more); \
+    }
+#else
+#define WRAPPER_FUNCTION_IMPLEMENTATIONS_CPP(tag, type)
+#endif
+
+#define WRAPPER_FUNCTION_IMPLEMENTATIONS(tag, type) \
+    WRAPPER_FUNCTION_IMPLEMENTATIONS_CORE(tag, type) \
+    WRAPPER_FUNCTION_IMPLEMENTATIONS_CPP(tag, type)
 
 ////////// UINT16
 

--- a/libdivide.h
+++ b/libdivide.h
@@ -122,65 +122,25 @@ namespace libdivide {
 // by up to 10% because of reduced memory bandwidth.
 #pragma pack(push, 1)
 
-struct libdivide_u16_t {
-    uint16_t magic;
-    uint8_t more;
-};
+#define STRUCT_NAME(tag) libdivide_ ##tag ##_t
+#define STRUCT_BRANCHFREE_NAME(tag) libdivide_ ##tag ##_branchfree_t
 
-struct libdivide_s16_t {
-    int16_t magic;
-    uint8_t more;
-};
+#define DEFINE_STRUCTS(tag, type) \
+    struct STRUCT_NAME(tag) { \
+        type magic; \
+        uint8_t more; \
+    }; \
+    struct STRUCT_BRANCHFREE_NAME(tag) { \
+        type magic; \
+        uint8_t more; \
+    };
 
-struct libdivide_u32_t {
-    uint32_t magic;
-    uint8_t more;
-};
-
-struct libdivide_s32_t {
-    int32_t magic;
-    uint8_t more;
-};
-
-struct libdivide_u64_t {
-    uint64_t magic;
-    uint8_t more;
-};
-
-struct libdivide_s64_t {
-    int64_t magic;
-    uint8_t more;
-};
-
-struct libdivide_u16_branchfree_t {
-    uint16_t magic;
-    uint8_t more;
-};
-
-struct libdivide_s16_branchfree_t {
-    int16_t magic;
-    uint8_t more;
-};
-
-struct libdivide_u32_branchfree_t {
-    uint32_t magic;
-    uint8_t more;
-};
-
-struct libdivide_s32_branchfree_t {
-    int32_t magic;
-    uint8_t more;
-};
-
-struct libdivide_u64_branchfree_t {
-    uint64_t magic;
-    uint8_t more;
-};
-
-struct libdivide_s64_branchfree_t {
-    int64_t magic;
-    uint8_t more;
-};
+DEFINE_STRUCTS(s16, int16_t)
+DEFINE_STRUCTS(u16, uint16_t)
+DEFINE_STRUCTS(s32, int32_t)
+DEFINE_STRUCTS(u32, uint32_t)
+DEFINE_STRUCTS(s64, int64_t)
+DEFINE_STRUCTS(u64, uint64_t)
 
 #pragma pack(pop)
 

--- a/libdivide.h
+++ b/libdivide.h
@@ -183,13 +183,12 @@ enum {
     LIBDIVIDE_NEGATIVE_DIVISOR = 0x80
 };
 
-#undef _CONCAT
-#define _CONCAT(x,y) x ## y
-#define CONCAT(x,y)  _CONCAT(x,y)
+#define _LD_CONCAT(x,y) x ## y
+#define LD_CONCAT(x,y) _LD_CONCAT(x,y)
 
 #define STRUCT_POSTFIX _t
 #define BRANCHFREE_POSTFIX _branchfree_t
-#define _STRUCT_NAME(tag, postfix) CONCAT(libdivide_, CONCAT(tag, postfix))
+#define _STRUCT_NAME(tag, postfix) LD_CONCAT(libdivide_, LD_CONCAT(tag, postfix))
 
 #define STRUCT_NAME(tag) _STRUCT_NAME(tag, STRUCT_POSTFIX)
 #define STRUCT_BRANCHFREE_NAME(tag) _STRUCT_NAME(tag, BRANCHFREE_POSTFIX)
@@ -205,12 +204,7 @@ enum {
         return result; \
     }
 
-// pack divider structs to prevent compilers from padding.
-// This reduces memory usage by up to 43% when using a large
-// array of libdivide dividers and improves performance
-// by up to 10% because of reduced memory bandwidth.
 #define DEFINE_STRUCTS(tag, type) \
-    _Pragma("pack(push, 1)") \
     struct STRUCT_NAME(tag) { \
         type magic; \
         uint8_t more; \
@@ -221,9 +215,8 @@ enum {
         uint8_t more; \
     }; \
     INLINE_CONSTRUCT_STRUCT_BRANCHFREE(tag, type) \
-    _Pragma("pack(pop)")
 
-#define FUNC_NAME_BUILDER(tag, postfix) CONCAT(libdivide_, CONCAT(tag, postfix))
+#define FUNC_NAME_BUILDER(tag, postfix) LD_CONCAT(libdivide_, LD_CONCAT(tag, postfix))
 
 // These need to be implemented by maintiners
 #define CORE_FUNCTION_DECLARATIONS(tag, type) \
@@ -270,12 +263,20 @@ enum {
     WRAPPER_FUNCTION_DECLARATIONS_CORE(tag, type) \
     WRAPPER_FUNCTION_DECLARATIONS_CPP(tag, type)
 
+// pack divider structs to prevent compilers from padding.
+// This reduces memory usage by up to 43% when using a large
+// array of libdivide dividers and improves performance
+// by up to 10% because of reduced memory bandwidth.
+#pragma pack(push, 1)
+
 DECLARE_TYPE(s16, int16_t)
 DECLARE_TYPE(u16, uint16_t)
 DECLARE_TYPE(s32, int32_t)
 DECLARE_TYPE(u32, uint32_t)
 DECLARE_TYPE(s64, int64_t)
 DECLARE_TYPE(u64, uint64_t)
+
+#pragma pack(pop)
 
 //////// Internal Utility Functions
 
@@ -379,7 +380,7 @@ static LIBDIVIDE_INLINE uint8_t libdivide_count_leading_zeros16(uint16_t val) {
 #elif defined(LIBDIVIDE_VC)
     unsigned long result;
     if (_BitScanReverse(&result, (unsigned long)val)) {
-        return (int16_t)(15 - result);
+        return (uint8_t)(15 - result);
     }
     return 0;
 #else
@@ -399,7 +400,7 @@ static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE uint8_t libdivide_count_leading_zero
         result -= 1U;
         hi <<= 1;
     }
-    return (uint8_t)result;
+    return result;
 }
 
 static LIBDIVIDE_INLINE uint8_t libdivide_count_leading_zeros32(uint32_t val) {
@@ -931,7 +932,7 @@ static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE bool libdivide_internal_u32_ispow2(u
 }
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE uint8_t libdivide_internal_u32_floor_log_2_d(uint8_t leading_zeroes) {
-    return (uint8_t)31U - leading_zeroes;
+    return (uint8_t)(31U - leading_zeroes);
 }
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_u32_t libdivide_internal_u32_gen_gen(
@@ -1315,7 +1316,10 @@ WRAPPER_FUNCTION_IMPLEMENTATIONS(u64, uint64_t)
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE uint16_t libdivide_internal_s16_abs(int16_t d) {
     uint16_t ud = (uint16_t)d;
+#pragma warning( push )
+#pragma warning( disable : 4146 )
     return (d < 0) ? -ud : ud;    
+#pragma warning( pop )
 }
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_s16_t libdivide_internal_s16_gen_gen(
@@ -1514,7 +1518,10 @@ WRAPPER_FUNCTION_IMPLEMENTATIONS(s16, int16_t)
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE uint32_t libdivide_internal_s32_abs(int32_t d) {
     uint32_t ud = (uint32_t)d;
-    return (d < 0) ? -ud : ud;    
+#pragma warning( push )
+#pragma warning( disable : 4146 )
+    return (d < 0) ? -ud : ud;
+#pragma warning( pop )
 }
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_s32_t libdivide_internal_s32_gen_gen(
@@ -1711,7 +1718,10 @@ WRAPPER_FUNCTION_IMPLEMENTATIONS(s32, int32_t)
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE uint64_t libdivide_internal_s64_abs(int64_t d) {
     uint64_t ud = (uint64_t)d;
+#pragma warning( push )
+#pragma warning( disable : 4146 )
     return (d < 0) ? -ud : ud;    
+#pragma warning( pop )    
 }
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_s64_t libdivide_internal_s64_gen_gen(

--- a/libdivide.h
+++ b/libdivide.h
@@ -496,7 +496,7 @@ struct libdivide_128_div_64_result_t {
 };
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_128_div_64_result_t libdivide_128_div_64_to_64_software(
-    uint64_t numhi, uint64_t numlo, uint64_t den, int32_t leading_zeroes) {
+    uint64_t numhi, uint64_t numlo, uint64_t den, uint8_t leading_zeroes) {
 
     // Check for overflow and divide by 0.
     if (numhi >= den) {
@@ -508,7 +508,7 @@ static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_128_div_64_result_t
     // A uint32 holds a single digit. A uint64 holds two digits.
     // Our numerator is conceptually [num3, num2, num1, num0].
     // Our denominator is [den1, den0].
-    const uint64_t b = ((uint64_t)1 << 32);
+    const uint64_t b = ((uint64_t)1U << 32U);
 
     // Determine the normalization factor. We multiply den by this, so that its leading digit is at
     // least half b. In binary this means just shifting left by the number of leading zeros, so that
@@ -1004,7 +1004,7 @@ static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_u32_t libdivide_int
         LIBDIVIDE_ERROR("divider must be != 0");
     }
 
-    uint32_t floor_log_2_d = libdivide_internal_u32_floor_log_2_d(libdivide_count_leading_zeros32_software(d));
+    uint8_t floor_log_2_d = libdivide_internal_u32_floor_log_2_d(libdivide_count_leading_zeros32_software(d));
     struct libdivide_64_div_32_result_t null_proposed_m = { 0U, 0U };
     struct libdivide_64_div_32_result_t proposed_m = libdivide_internal_u32_ispow2(d) ? null_proposed_m : libdivide_64_div_32_to_32_software((uint32_t)1 << floor_log_2_d, 0, d);  
     return libdivide_internal_u32_gen_gen(d, branchfree, floor_log_2_d, proposed_m);
@@ -1116,7 +1116,7 @@ static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE bool libdivide_internal_u64_ispow2(u
 }
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_u64_t libdivide_internal_u64_gen_gen(
-    uint64_t d, bool branchfree, uint32_t floor_log_2_d, struct libdivide_128_div_64_result_t proposed_m) {
+    uint64_t d, bool branchfree, uint8_t floor_log_2_d, struct libdivide_128_div_64_result_t proposed_m) {
     if (d == 0) {
         LIBDIVIDE_ERROR("divider must be != 0");
     }
@@ -1169,7 +1169,7 @@ static LIBDIVIDE_INLINE struct libdivide_u64_t libdivide_internal_u64_gen(
         LIBDIVIDE_ERROR("divider must be != 0");
     }
 
-    uint32_t floor_log_2_d = libdivide_internal_u64_floor_log_2_d(libdivide_count_leading_zeros64(d));
+    uint8_t floor_log_2_d = libdivide_internal_u64_floor_log_2_d(libdivide_count_leading_zeros64(d));
     struct libdivide_128_div_64_result_t null_proposed_m = { 0U, 0U };
     struct libdivide_128_div_64_result_t proposed_m = libdivide_internal_u64_ispow2(d) ? null_proposed_m : libdivide_128_div_64_to_64((uint64_t)1 << floor_log_2_d, 0, d);  
     return libdivide_internal_u64_gen_gen(d, branchfree, floor_log_2_d, proposed_m);
@@ -1193,7 +1193,7 @@ static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_u64_t libdivide_int
     }
 
     uint8_t leading_zeroes = libdivide_count_leading_zeros64_software(d);
-    uint32_t floor_log_2_d = libdivide_internal_u64_floor_log_2_d(leading_zeroes);
+    uint8_t floor_log_2_d = libdivide_internal_u64_floor_log_2_d(leading_zeroes);
     struct libdivide_128_div_64_result_t null_proposed_m = { 0U, 0U };
     struct libdivide_128_div_64_result_t proposed_m = libdivide_internal_u64_ispow2(d) ? null_proposed_m : libdivide_128_div_64_to_64_software((uint64_t)1 << floor_log_2_d, 0, d, leading_zeroes);  
     return libdivide_internal_u64_gen_gen(d, branchfree, floor_log_2_d, proposed_m);
@@ -1715,7 +1715,7 @@ static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE uint64_t libdivide_internal_s64_abs(
 }
 
 static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_s64_t libdivide_internal_s64_gen_gen(
-    int64_t d, bool branchfree, uint32_t floor_log_2_d, struct libdivide_128_div_64_result_t proposed_m) {
+    int64_t d, bool branchfree, uint8_t floor_log_2_d, struct libdivide_128_div_64_result_t proposed_m) {
     if (d == 0) {
         LIBDIVIDE_ERROR("divider must be != 0");
     }
@@ -1777,7 +1777,7 @@ static LIBDIVIDE_INLINE struct libdivide_s64_t libdivide_internal_s64_gen(int64_
     }
 
     uint64_t absD = libdivide_internal_s64_abs(d);
-    uint32_t floor_log_2_d = libdivide_internal_u64_floor_log_2_d(libdivide_count_leading_zeros64(absD));
+    uint8_t floor_log_2_d = libdivide_internal_u64_floor_log_2_d(libdivide_count_leading_zeros64(absD));
     struct libdivide_128_div_64_result_t null_proposed_m = { 0U, 0U };
     struct libdivide_128_div_64_result_t proposed_m = libdivide_internal_u64_ispow2(absD) ? null_proposed_m : libdivide_128_div_64_to_64((uint64_t)1 << (floor_log_2_d - 1), 0, absD);
     return libdivide_internal_s64_gen_gen(d, branchfree, floor_log_2_d, proposed_m);
@@ -1802,7 +1802,7 @@ static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct libdivide_s64_t libdivide_int
 
     uint64_t absD = libdivide_internal_s64_abs(d);
     uint8_t leading_zeroes = libdivide_count_leading_zeros64_software(absD);
-    uint32_t floor_log_2_d = libdivide_internal_u64_floor_log_2_d(leading_zeroes);
+    uint8_t floor_log_2_d = libdivide_internal_u64_floor_log_2_d(leading_zeroes);
     struct libdivide_128_div_64_result_t null_proposed_m = { 0U, 0U };
     struct libdivide_128_div_64_result_t proposed_m = libdivide_internal_u64_ispow2(absD) ? null_proposed_m : libdivide_128_div_64_to_64_software((uint64_t)1 << (floor_log_2_d - 1), 0, absD, leading_zeroes);
     return libdivide_internal_s64_gen_gen(d, branchfree, floor_log_2_d, proposed_m);

--- a/libdivide.h
+++ b/libdivide.h
@@ -232,7 +232,15 @@ enum {
     static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _recover_raw)(type magic, uint8_t more); \
     static LIBDIVIDE_INLINE struct STRUCT_BRANCHFREE_NAME(tag) FUNC_NAME_BUILDER(tag, _branchfree_gen)(type d); \
     static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _branchfree_do_raw)(type numer, type magic, uint8_t more); \
-    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _branchfree_recover_raw)(type magic, uint8_t more); \
+    static LIBDIVIDE_INLINE type FUNC_NAME_BUILDER(tag, _branchfree_recover_raw)(type magic, uint8_t more);
+
+#if defined(__cplusplus) && defined(LIBDIVIDE_HAS_CONSTEXPR) && LIBDIVIDE_HAS_CONSTEXPR>0
+#define CONSTEXPR_FUNCTION_DECLARATIONS(tag, type) \
+    static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct STRUCT_NAME(tag) FUNC_NAME_BUILDER(tag, _gen_c)(type d); \
+    static LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE struct STRUCT_BRANCHFREE_NAME(tag) FUNC_NAME_BUILDER(tag, _branchfree_gen_c)(type d);
+#else
+#define CONSTEXPR_FUNCTION_DECLARATIONS(tag, type)
+#endif
 
 // Both the declaration of these AND the implementation of these can be automated
 // See WRAPPER_FUNCTION_IMPLEMENTATIONS_CPP
@@ -258,6 +266,7 @@ enum {
 #define DECLARE_TYPE(tag, type) \
     DEFINE_STRUCTS(tag, type) \
     CORE_FUNCTION_DECLARATIONS(tag, type) \
+    CONSTEXPR_FUNCTION_DECLARATIONS(tag, type) \
     WRAPPER_FUNCTION_DECLARATIONS_CORE(tag, type) \
     WRAPPER_FUNCTION_DECLARATIONS_CPP(tag, type)
 

--- a/test/avr/.vscode/extensions.json
+++ b/test/avr/.vscode/extensions.json
@@ -3,5 +3,8 @@
     // for the documentation about the extensions.json format
     "recommendations": [
         "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
     ]
 }

--- a/test/avr/platformio.ini
+++ b/test/avr/platformio.ini
@@ -20,8 +20,9 @@ platform = atmelavr
 board = megaatmega2560
 framework = arduino
 debug_tool = simavr
-debug_build_flags = -O0 -ggdb3 -g3
-common_build_flags = -std=c++11 -Wall -Wextra -D MONITOR_SPEED=${env.monitor_speed} -I ../..
+build_unflags = -std=gnu++11
+debug_build_flags = -std=c++14 -O0 -ggdb3 -g3
+common_build_flags = -std=c++14 -Wall -Wextra -D MONITOR_SPEED=${env.monitor_speed} -I ../..
 
 [env:megaatmega2560_Test]
 extends = megaatmega2560_base
@@ -29,7 +30,7 @@ build_flags = ${megaatmega2560_base.common_build_flags} -D TEST_LIBDIVIDE -D PRI
 
 [megaatmega2560_benchmark_base]
 extends = megaatmega2560_base
-build_unflags = -Os
+build_unflags = ${megaatmega2560_base.build_unflags} -Os
 common_build_flags = ${megaatmega2560_base.common_build_flags} -O3 -ffast-math -Wl,-u,vfprintf -lprintf_flt
 
 [env:megaatmega2560_Benchmark_S16]
@@ -59,30 +60,30 @@ build_flags = ${megaatmega2560_benchmark_base.common_build_flags} -D BENCHMARK -
 [env:megaatmega2560_ConstantTestDivSigned]
 extends = megaatmega2560_base
 extra_scripts = ${env.extra_scripts}, pre:./src/invariant_div_test/gen_constant_tests.py
-build_unflags = -Os
+build_unflags = ${megaatmega2560_base.build_unflags} -Os
 build_flags = ${megaatmega2560_base.common_build_flags} -O3 -ffast-math -funroll-loops -D TEST_DIV -D TEST_CONSTANTS -save-temps=obj
 
 [env:megaatmega2560_ConstantTestDivSignedTemplates]
 extends = megaatmega2560_base
 extra_scripts = ${env.extra_scripts}, pre:./src/invariant_div_test/gen_constant_tests.py
-build_unflags = -Os
+build_unflags = ${megaatmega2560_base.build_unflags} -Os
 build_flags = ${megaatmega2560_base.common_build_flags} -O3 -ffast-math -funroll-loops -D TEST_DIV -D TEST_CONSTANTS -D TEST_CPP_TEMPLATE -save-temps=obj
 
 [env:megaatmega2560_ConstantTestDivUnsigned]
 extends = megaatmega2560_base
 extra_scripts = ${env.extra_scripts}, pre:./src/invariant_div_test/gen_constant_tests.py
-build_unflags = -Os
+build_unflags = ${megaatmega2560_base.build_unflags} -Os
 build_flags = ${megaatmega2560_base.common_build_flags} -O3 -ffast-math -funroll-loops -D TEST_DIV -D TEST_CONSTANTS -D TEST_UNSIGNED -save-temps=obj
 
 
 [env:megaatmega2560_ConstantTestDivUnsignedTemplates]
 extends = megaatmega2560_base
 extra_scripts = ${env.extra_scripts}, pre:./src/invariant_div_test/gen_constant_tests.py
-build_unflags = -Os
+build_unflags = ${megaatmega2560_base.build_unflags} -Os
 build_flags = ${megaatmega2560_base.common_build_flags} -O3 -ffast-math -funroll-loops -D TEST_DIV -D TEST_CONSTANTS -D TEST_UNSIGNED -D TEST_CPP_TEMPLATE -save-temps=obj
 
 [env:megaatmega2560_ConstantTestMod]
 extends = megaatmega2560_base
 extra_scripts = ${env.extra_scripts}, pre:./src/invariant_div_test/gen_constant_tests.py
-build_unflags = -Os
+build_unflags = ${megaatmega2560_base.build_unflags} -Os
 build_flags = ${megaatmega2560_base.common_build_flags} -O3 -ffast-math -funroll-loops -D TEST_MOD -D TEST_CONSTANTS -D TEST_UNSIGNED -save-temps=obj

--- a/test/avr/src/constexpr_test.cpp
+++ b/test/avr/src/constexpr_test.cpp
@@ -1,0 +1,1 @@
+#include "../../constexpr_test.cpp"

--- a/test/avr/src/invariant_div_test/constant_macros.h
+++ b/test/avr/src/invariant_div_test/constant_macros.h
@@ -3,8 +3,8 @@
 #include <stdint.h>
 
 #define CAT_HELPER(a, b) a ## b
-#define CONCAT(A, B) CAT_HELPER(A, B)
-#define TEST_FUNC_NAME(Op, Denom) CONCAT(CONCAT(test, Op), Denom)
+#define LD_CONCAT(A, B) CAT_HELPER(A, B)
+#define TEST_FUNC_NAME(Op, Denom) LD_CONCAT(LD_CONCAT(test, Op), Denom)
 
 #if TEST_UNSIGNED
 typedef uint16_t test_t;

--- a/test/avr/src/main.cpp
+++ b/test/avr/src/main.cpp
@@ -4,6 +4,7 @@
 #include "..\..\benchmark.h"
 #elif defined(TEST_LIBDIVIDE)
 #include "..\..\DivideTest.h"
+#include "..\..\constexpr_test.h"
 #elif defined(TEST_CONSTANTS)
 #include "invariant_div_test/Constant_Div_Tests.h"
 #endif
@@ -28,6 +29,7 @@ void setup() {
 #endif
 
 #elif defined(TEST_LIBDIVIDE)
+  test_constexpr();
   run_test<int16_t>();
   run_test<uint16_t>();
   run_test<int32_t>();

--- a/test/constexpr_test.cpp
+++ b/test/constexpr_test.cpp
@@ -30,14 +30,12 @@ void test_constexpr(void) {
     //     assert_constexpr(libdivide::libdivide_s16_do(dividend, constexprS16), dividend, divisor);
     //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_s16_branchfree_do(dividend, constexprS16BF), dividend, divisor);
     // }
-    // {
-    //     constexpr uint16_t dividend = 17359;
-    //     constexpr uint16_t divisor = 99;
-    //     constexpr auto constexprU16 = libdivide::libdivide_u16_gen(divisor);
-    //     assert_constexpr(libdivide::libdivide_u16_do(dividend, constexprU16), dividend, divisor);
-    //     constexpr auto constexprU16BF = libdivide::libdivide_u16_branchfree_gen(divisor);
-    //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_u16_branchfree_do(dividend, constexprU16BF), dividend, divisor);
-    // }
+    {
+        constexpr uint16_t dividend = 17359;
+        uint16_t divisor = libdivide::libdivide_u16_recover(constexprU16);
+        assert_constexpr(libdivide::libdivide_u16_do(dividend, constexprU16), dividend, divisor);
+        std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_u16_branchfree_do(dividend, constexprU16BF), dividend, divisor);
+    }
     {
         constexpr int32_t dividend = INT32_MAX/7U;
         int32_t divisor = libdivide::libdivide_s32_recover(constexprS32);

--- a/test/constexpr_test.cpp
+++ b/test/constexpr_test.cpp
@@ -1,16 +1,27 @@
-#include <iostream>
 #include "constexpr_test.h"
-
+#include "outputs.h"
 
 template <typename _IntT>
 static void assert_constexpr(_IntT result, _IntT dividend, _IntT divisor) {
     _IntT expected = dividend / divisor;
-    std::cout << typeid(_IntT).name() << " constexpr generation: " 
-        << dividend << " / " << divisor << " = "  << result 
-        << " (" << expected << (result==expected ? ") passed" : ") **FAILED") << std::endl;
+    PRINT_INFO(F("Testing constexpr generation: "));
+    PRINT_INFO(__PRETTY_FUNCTION__);
+    PRINT_INFO(": ");
+    PRINT_INFO(dividend);
+    PRINT_INFO(" / ");
+    PRINT_INFO(divisor);
+    PRINT_INFO(" = ");
+    PRINT_INFO(expected);
+    if (result!=expected) {
+        PRINT_ERROR(F(" FAILED  ("));
+        PRINT_ERROR(result);
+        PRINT_ERROR(F(")"));
+        PRINT_ERROR(F("\n"));
+        exit(1);
+    } else {
+        PRINT_INFO(F("\n"));
+    }
 }
-
-
 void test_constexpr(void) {
     // {
     //     constexpr int16_t dividend = -17359;
@@ -42,14 +53,12 @@ void test_constexpr(void) {
     //     constexpr auto constexprU32BF = libdivide::libdivide_u32_branchfree_gen(divisor);
     //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_u32_branchfree_do(dividend, constexprU32BF), dividend, divisor);
     // }   
-    // {
-    //     constexpr int64_t dividend = INT64_MAX/7U;
-    //     constexpr int64_t divisor = INT64_MAX/-123;
-    //     constexpr auto constexprS64 = libdivide::libdivide_s64_gen(divisor);
-    //     assert_constexpr(libdivide::libdivide_s64_do(dividend, constexprS64), dividend, divisor);
-    //     constexpr auto constexprS64BF = libdivide::libdivide_s64_branchfree_gen(divisor);
-    //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_s64_branchfree_do(dividend, constexprS64BF), dividend, divisor);
-    // } 
+    {
+        constexpr int64_t dividend = INT64_MAX/7U;
+        int64_t divisor = libdivide::libdivide_s64_recover(constexprS64);
+        assert_constexpr(libdivide::libdivide_s64_do(dividend, constexprS64), dividend, divisor);
+        std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_s64_branchfree_do(dividend, constexprS64BF), dividend, divisor);
+    } 
     {
         constexpr uint64_t dividend = UINT64_MAX/7U;
         uint64_t divisor = libdivide::libdivide_u64_recover(constexprU64);

--- a/test/constexpr_test.cpp
+++ b/test/constexpr_test.cpp
@@ -1,0 +1,59 @@
+#include <iostream>
+#include "constexpr_test.h"
+
+
+template <typename _IntT>
+static void assert_constexpr(_IntT result, _IntT dividend, _IntT divisor) {
+    _IntT expected = dividend / divisor;
+    std::cout << typeid(_IntT).name() << " constexpr generation: " 
+        << dividend << " / " << divisor << " = "  << result 
+        << " (" << expected << (result==expected ? ") passed" : ") **FAILED") << std::endl;
+}
+
+
+void test_constexpr(void) {
+    // {
+    //     constexpr int16_t dividend = -17359;
+    //     int16_t divisor = libdivide::libdivide_s16_recover(constexprS16);
+    //     assert_constexpr(libdivide::libdivide_s16_do(dividend, constexprS16), dividend, divisor);
+    //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_s16_branchfree_do(dividend, constexprS16BF), dividend, divisor);
+    // }
+    // {
+    //     constexpr uint16_t dividend = 17359;
+    //     constexpr uint16_t divisor = 99;
+    //     constexpr auto constexprU16 = libdivide::libdivide_u16_gen(divisor);
+    //     assert_constexpr(libdivide::libdivide_u16_do(dividend, constexprU16), dividend, divisor);
+    //     constexpr auto constexprU16BF = libdivide::libdivide_u16_branchfree_gen(divisor);
+    //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_u16_branchfree_do(dividend, constexprU16BF), dividend, divisor);
+    // }
+    // {
+    //     constexpr int32_t dividend = INT32_MAX/7U;
+    //     constexpr int32_t divisor = INT32_MAX/-123;
+    //     constexpr auto constexprS32 = libdivide::libdivide_s32_gen(divisor);
+    //     assert_constexpr(libdivide::libdivide_s32_do(dividend, constexprS32), dividend, divisor);
+    //     constexpr auto constexprS32BF = libdivide::libdivide_s32_branchfree_gen(divisor);
+    //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_s32_branchfree_do(dividend, constexprS32BF), dividend, divisor);
+    // }    
+    // {
+    //     constexpr uint32_t dividend = UINT32_MAX/7U;
+    //     constexpr uint32_t divisor = UINT32_MAX/123;
+    //     constexpr auto constexprU32 = libdivide::libdivide_u32_gen(divisor);
+    //     assert_constexpr(libdivide::libdivide_u32_do(dividend, constexprU32), dividend, divisor);
+    //     constexpr auto constexprU32BF = libdivide::libdivide_u32_branchfree_gen(divisor);
+    //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_u32_branchfree_do(dividend, constexprU32BF), dividend, divisor);
+    // }   
+    // {
+    //     constexpr int64_t dividend = INT64_MAX/7U;
+    //     constexpr int64_t divisor = INT64_MAX/-123;
+    //     constexpr auto constexprS64 = libdivide::libdivide_s64_gen(divisor);
+    //     assert_constexpr(libdivide::libdivide_s64_do(dividend, constexprS64), dividend, divisor);
+    //     constexpr auto constexprS64BF = libdivide::libdivide_s64_branchfree_gen(divisor);
+    //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_s64_branchfree_do(dividend, constexprS64BF), dividend, divisor);
+    // } 
+    {
+        constexpr uint64_t dividend = UINT64_MAX/7U;
+        uint64_t divisor = libdivide::libdivide_u64_recover(constexprU64);
+        assert_constexpr(libdivide::libdivide_u64_do(dividend, constexprU64), dividend, divisor);
+        std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_u64_branchfree_do(dividend, constexprU64BF), dividend, divisor);
+    }          
+}

--- a/test/constexpr_test.cpp
+++ b/test/constexpr_test.cpp
@@ -45,14 +45,12 @@ void test_constexpr(void) {
     //     constexpr auto constexprS32BF = libdivide::libdivide_s32_branchfree_gen(divisor);
     //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_s32_branchfree_do(dividend, constexprS32BF), dividend, divisor);
     // }    
-    // {
-    //     constexpr uint32_t dividend = UINT32_MAX/7U;
-    //     constexpr uint32_t divisor = UINT32_MAX/123;
-    //     constexpr auto constexprU32 = libdivide::libdivide_u32_gen(divisor);
-    //     assert_constexpr(libdivide::libdivide_u32_do(dividend, constexprU32), dividend, divisor);
-    //     constexpr auto constexprU32BF = libdivide::libdivide_u32_branchfree_gen(divisor);
-    //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_u32_branchfree_do(dividend, constexprU32BF), dividend, divisor);
-    // }   
+    {
+        constexpr uint32_t dividend = UINT32_MAX/7U;
+        uint32_t divisor = libdivide::libdivide_u32_recover(constexprU32);
+        assert_constexpr(libdivide::libdivide_u32_do(dividend, constexprU32), dividend, divisor);
+        std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_u32_branchfree_do(dividend, constexprU32BF), dividend, divisor);
+    }   
     {
         constexpr int64_t dividend = INT64_MAX/7U;
         int64_t divisor = libdivide::libdivide_s64_recover(constexprS64);

--- a/test/constexpr_test.cpp
+++ b/test/constexpr_test.cpp
@@ -1,18 +1,19 @@
 #include "constexpr_test.h"
 #include "outputs.h"
+#include "type_mappings.h"
 
 template <typename _IntT>
 static void assert_constexpr(_IntT result, _IntT dividend, _IntT divisor) {
     _IntT expected = dividend / divisor;
     PRINT_INFO(F("Testing constexpr generation: "));
-    PRINT_INFO(__PRETTY_FUNCTION__);
-    PRINT_INFO(": ");
-    PRINT_INFO(dividend);
-    PRINT_INFO(" / ");
-    PRINT_INFO(divisor);
-    PRINT_INFO(" = ");
-    PRINT_INFO(expected);
+    PRINT_INFO(type_name<_IntT>::get_name());
     if (result!=expected) {
+        PRINT_INFO(": ");
+        PRINT_INFO(dividend);
+        PRINT_INFO(" / ");
+        PRINT_INFO(divisor);
+        PRINT_INFO(" = ");
+        PRINT_INFO(expected);
         PRINT_ERROR(F(" FAILED  ("));
         PRINT_ERROR(result);
         PRINT_ERROR(F(")"));
@@ -37,14 +38,12 @@ void test_constexpr(void) {
     //     constexpr auto constexprU16BF = libdivide::libdivide_u16_branchfree_gen(divisor);
     //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_u16_branchfree_do(dividend, constexprU16BF), dividend, divisor);
     // }
-    // {
-    //     constexpr int32_t dividend = INT32_MAX/7U;
-    //     constexpr int32_t divisor = INT32_MAX/-123;
-    //     constexpr auto constexprS32 = libdivide::libdivide_s32_gen(divisor);
-    //     assert_constexpr(libdivide::libdivide_s32_do(dividend, constexprS32), dividend, divisor);
-    //     constexpr auto constexprS32BF = libdivide::libdivide_s32_branchfree_gen(divisor);
-    //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_s32_branchfree_do(dividend, constexprS32BF), dividend, divisor);
-    // }    
+    {
+        constexpr int32_t dividend = INT32_MAX/7U;
+        int32_t divisor = libdivide::libdivide_s32_recover(constexprS32);
+        assert_constexpr(libdivide::libdivide_s32_do(dividend, constexprS32), dividend, divisor);
+        std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_s32_branchfree_do(dividend, constexprS32BF), dividend, divisor);
+    }    
     {
         constexpr uint32_t dividend = UINT32_MAX/7U;
         uint32_t divisor = libdivide::libdivide_u32_recover(constexprU32);

--- a/test/constexpr_test.cpp
+++ b/test/constexpr_test.cpp
@@ -3,10 +3,14 @@
 #include "type_mappings.h"
 
 template <typename _IntT>
-static void assert_constexpr(_IntT result, _IntT dividend, _IntT divisor) {
-    _IntT expected = dividend / divisor;
-    PRINT_INFO(F("Testing constexpr generation: "));
+static void assert_constexpr(_IntT result, _IntT dividend, _IntT divisor, bool branchFree = false) {
+    PRINT_INFO(F("Testing "));
+    if (branchFree) {
+        PRINT_INFO(F("branch free "));
+    }
     PRINT_INFO(type_name<_IntT>::get_name());
+    PRINT_INFO(F(" constexpr generation"));
+    _IntT expected = dividend / divisor;
     if (result!=expected) {
         PRINT_INFO(": ");
         PRINT_INFO(dividend);
@@ -24,40 +28,40 @@ static void assert_constexpr(_IntT result, _IntT dividend, _IntT divisor) {
     }
 }
 void test_constexpr(void) {
-    // {
-    //     constexpr int16_t dividend = -17359;
-    //     int16_t divisor = libdivide::libdivide_s16_recover(constexprS16);
-    //     assert_constexpr(libdivide::libdivide_s16_do(dividend, constexprS16), dividend, divisor);
-    //     std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_s16_branchfree_do(dividend, constexprS16BF), dividend, divisor);
-    // }
+    {
+        constexpr int16_t dividend = -17359;
+        int16_t divisor = libdivide::libdivide_s16_recover(constexprS16);
+        assert_constexpr(libdivide::libdivide_s16_do(dividend, constexprS16), dividend, divisor);
+        assert_constexpr(libdivide::libdivide_s16_branchfree_do(dividend, constexprS16BF), dividend, divisor, true);
+    }
     {
         constexpr uint16_t dividend = 17359;
         uint16_t divisor = libdivide::libdivide_u16_recover(constexprU16);
         assert_constexpr(libdivide::libdivide_u16_do(dividend, constexprU16), dividend, divisor);
-        std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_u16_branchfree_do(dividend, constexprU16BF), dividend, divisor);
+        assert_constexpr(libdivide::libdivide_u16_branchfree_do(dividend, constexprU16BF), dividend, divisor, true);
     }
     {
         constexpr int32_t dividend = INT32_MAX/7U;
         int32_t divisor = libdivide::libdivide_s32_recover(constexprS32);
         assert_constexpr(libdivide::libdivide_s32_do(dividend, constexprS32), dividend, divisor);
-        std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_s32_branchfree_do(dividend, constexprS32BF), dividend, divisor);
+        assert_constexpr(libdivide::libdivide_s32_branchfree_do(dividend, constexprS32BF), dividend, divisor, true);
     }    
     {
         constexpr uint32_t dividend = UINT32_MAX/7U;
         uint32_t divisor = libdivide::libdivide_u32_recover(constexprU32);
         assert_constexpr(libdivide::libdivide_u32_do(dividend, constexprU32), dividend, divisor);
-        std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_u32_branchfree_do(dividend, constexprU32BF), dividend, divisor);
+        assert_constexpr(libdivide::libdivide_u32_branchfree_do(dividend, constexprU32BF), dividend, divisor, true);
     }   
     {
         constexpr int64_t dividend = INT64_MAX/7U;
         int64_t divisor = libdivide::libdivide_s64_recover(constexprS64);
         assert_constexpr(libdivide::libdivide_s64_do(dividend, constexprS64), dividend, divisor);
-        std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_s64_branchfree_do(dividend, constexprS64BF), dividend, divisor);
+        assert_constexpr(libdivide::libdivide_s64_branchfree_do(dividend, constexprS64BF), dividend, divisor, true);
     } 
     {
         constexpr uint64_t dividend = UINT64_MAX/7U;
         uint64_t divisor = libdivide::libdivide_u64_recover(constexprU64);
         assert_constexpr(libdivide::libdivide_u64_do(dividend, constexprU64), dividend, divisor);
-        std::cout << "Branch free "; assert_constexpr(libdivide::libdivide_u64_branchfree_do(dividend, constexprU64BF), dividend, divisor);
+        assert_constexpr(libdivide::libdivide_u64_branchfree_do(dividend, constexprU64BF), dividend, divisor, true);
     }          
 }

--- a/test/constexpr_test.h
+++ b/test/constexpr_test.h
@@ -1,6 +1,16 @@
 #pragma once
 #include "libdivide.h"
 
+// For constexpr, MSVC 17 has some unwanted warnings *at the call site*
+#if defined(_MSC_VER)
+#pragma warning(push)
+// disable warning C4146: unary minus operator applied
+// to unsigned type, result still unsigned
+#pragma warning(disable : 4146)
+// disable warning C4307: integral constant overflow
+#pragma warning(disable : 4307)
+#endif
+
 constexpr auto constexprS16 = libdivide::libdivide_s16_gen_c(99);
 constexpr auto constexprS16BF = libdivide::libdivide_s16_branchfree_gen_c(99);
 constexpr auto constexprU16 = libdivide::libdivide_u16_gen_c(99);
@@ -13,5 +23,9 @@ constexpr auto constexprS64 = libdivide::libdivide_s64_gen_c(INT64_MAX/-123);
 constexpr auto constexprS64BF = libdivide::libdivide_s64_branchfree_gen_c(INT64_MAX/-123);
 constexpr auto constexprU64 = libdivide::libdivide_u64_gen_c(UINT64_MAX/123);
 constexpr auto constexprU64BF = libdivide::libdivide_u64_branchfree_gen_c(UINT64_MAX/123);
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 void test_constexpr(void);

--- a/test/constexpr_test.h
+++ b/test/constexpr_test.h
@@ -5,8 +5,8 @@
 // constexpr auto constexprS16BF = libdivide::libdivide_s16_branchfree_gen(99);
 // constexpr auto constexprU16 = libdivide::libdivide_u16_gen(99);
 // constexpr auto constexprU16BF = libdivide::libdivide_u16_branchfree_gen(99);
-// constexpr auto constexprS32 = libdivide::libdivide_s32_gen(INT32_MAX/-123);
-// constexpr auto constexprS32BF = libdivide::libdivide_s32_branchfree_gen(INT32_MAX/-123);
+constexpr auto constexprS32 = libdivide::libdivide_s32_gen_c(INT32_MAX/-123);
+constexpr auto constexprS32BF = libdivide::libdivide_s32_branchfree_gen_c(INT32_MAX/-123);
 constexpr auto constexprU32 = libdivide::libdivide_u32_gen_c(UINT32_MAX/123);
 constexpr auto constexprU32BF = libdivide::libdivide_u32_branchfree_gen_c(UINT32_MAX/123);
 constexpr auto constexprS64 = libdivide::libdivide_s64_gen_c(INT64_MAX/-123);

--- a/test/constexpr_test.h
+++ b/test/constexpr_test.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "libdivide.h"
+
+// constexpr auto constexprS16 = libdivide::libdivide_s16_gen(99);
+// constexpr auto constexprS16BF = libdivide::libdivide_s16_branchfree_gen(99);
+// constexpr auto constexprU16 = libdivide::libdivide_u16_gen(99);
+// constexpr auto constexprU16BF = libdivide::libdivide_u16_branchfree_gen(99);
+// constexpr auto constexprS32 = libdivide::libdivide_s32_gen(INT32_MAX/-123);
+// constexpr auto constexprS32BF = libdivide::libdivide_s32_branchfree_gen(INT32_MAX/-123);
+// constexpr auto constexprU32 = libdivide::libdivide_u32_gen(UINT32_MAX/123);
+// constexpr auto constexprU32BF = libdivide::libdivide_u32_branchfree_gen(UINT32_MAX/123);
+// constexpr auto constexprS64 = libdivide::libdivide_s64_gen(INT64_MAX/-123);
+// constexpr auto constexprS64BF = libdivide::libdivide_s64_branchfree_gen(INT64_MAX/-123);
+constexpr auto constexprU64 = libdivide::libdivide_u64_gen_c(UINT64_MAX/123);
+constexpr auto constexprU64BF = libdivide::libdivide_u64_branchfree_gen_c(UINT64_MAX/123);
+
+void test_constexpr(void);

--- a/test/constexpr_test.h
+++ b/test/constexpr_test.h
@@ -7,8 +7,8 @@
 // constexpr auto constexprU16BF = libdivide::libdivide_u16_branchfree_gen(99);
 // constexpr auto constexprS32 = libdivide::libdivide_s32_gen(INT32_MAX/-123);
 // constexpr auto constexprS32BF = libdivide::libdivide_s32_branchfree_gen(INT32_MAX/-123);
-// constexpr auto constexprU32 = libdivide::libdivide_u32_gen(UINT32_MAX/123);
-// constexpr auto constexprU32BF = libdivide::libdivide_u32_branchfree_gen(UINT32_MAX/123);
+constexpr auto constexprU32 = libdivide::libdivide_u32_gen_c(UINT32_MAX/123);
+constexpr auto constexprU32BF = libdivide::libdivide_u32_branchfree_gen_c(UINT32_MAX/123);
 constexpr auto constexprS64 = libdivide::libdivide_s64_gen_c(INT64_MAX/-123);
 constexpr auto constexprS64BF = libdivide::libdivide_s64_branchfree_gen_c(INT64_MAX/-123);
 constexpr auto constexprU64 = libdivide::libdivide_u64_gen_c(UINT64_MAX/123);

--- a/test/constexpr_test.h
+++ b/test/constexpr_test.h
@@ -1,8 +1,8 @@
 #pragma once
 #include "libdivide.h"
 
-// constexpr auto constexprS16 = libdivide::libdivide_s16_gen(99);
-// constexpr auto constexprS16BF = libdivide::libdivide_s16_branchfree_gen(99);
+constexpr auto constexprS16 = libdivide::libdivide_s16_gen_c(99);
+constexpr auto constexprS16BF = libdivide::libdivide_s16_branchfree_gen_c(99);
 constexpr auto constexprU16 = libdivide::libdivide_u16_gen_c(99);
 constexpr auto constexprU16BF = libdivide::libdivide_u16_branchfree_gen_c(99);
 constexpr auto constexprS32 = libdivide::libdivide_s32_gen_c(INT32_MAX/-123);

--- a/test/constexpr_test.h
+++ b/test/constexpr_test.h
@@ -3,8 +3,8 @@
 
 // constexpr auto constexprS16 = libdivide::libdivide_s16_gen(99);
 // constexpr auto constexprS16BF = libdivide::libdivide_s16_branchfree_gen(99);
-// constexpr auto constexprU16 = libdivide::libdivide_u16_gen(99);
-// constexpr auto constexprU16BF = libdivide::libdivide_u16_branchfree_gen(99);
+constexpr auto constexprU16 = libdivide::libdivide_u16_gen_c(99);
+constexpr auto constexprU16BF = libdivide::libdivide_u16_branchfree_gen_c(99);
 constexpr auto constexprS32 = libdivide::libdivide_s32_gen_c(INT32_MAX/-123);
 constexpr auto constexprS32BF = libdivide::libdivide_s32_branchfree_gen_c(INT32_MAX/-123);
 constexpr auto constexprU32 = libdivide::libdivide_u32_gen_c(UINT32_MAX/123);

--- a/test/constexpr_test.h
+++ b/test/constexpr_test.h
@@ -9,8 +9,8 @@
 // constexpr auto constexprS32BF = libdivide::libdivide_s32_branchfree_gen(INT32_MAX/-123);
 // constexpr auto constexprU32 = libdivide::libdivide_u32_gen(UINT32_MAX/123);
 // constexpr auto constexprU32BF = libdivide::libdivide_u32_branchfree_gen(UINT32_MAX/123);
-// constexpr auto constexprS64 = libdivide::libdivide_s64_gen(INT64_MAX/-123);
-// constexpr auto constexprS64BF = libdivide::libdivide_s64_branchfree_gen(INT64_MAX/-123);
+constexpr auto constexprS64 = libdivide::libdivide_s64_gen_c(INT64_MAX/-123);
+constexpr auto constexprS64BF = libdivide::libdivide_s64_branchfree_gen_c(INT64_MAX/-123);
 constexpr auto constexprU64 = libdivide::libdivide_u64_gen_c(UINT64_MAX/123);
 constexpr auto constexprU64BF = libdivide::libdivide_u64_branchfree_gen_c(UINT64_MAX/123);
 

--- a/test/outputs.h
+++ b/test/outputs.h
@@ -51,6 +51,8 @@ void print_serial(const int64_t &item)
 #define PRINT_INFO(item) print_serial(item)
 
 #else
+#pragma warning( push )
+#pragma warning( disable : 4996 )
 
 static inline char *to_str(char *buffer, uint64_t n) {
     sprintf(buffer, "%" PRIu64, n);
@@ -60,6 +62,7 @@ static inline char *to_str(char *buffer, int64_t n) {
     sprintf(buffer, "%" PRId64, n);
     return buffer;
 }
+#pragma warning( pop )
 
 #include <iostream>
 
@@ -74,6 +77,8 @@ static inline char *to_str(char *buffer, int64_t n) {
 #else
 #define PRINT_PROGRESS_MSG(item)
 #endif
+#pragma warning( push )
+#pragma warning( disable : 4996 )
 
 static inline char *to_str(char *buffer, uint32_t n) {
     sprintf(buffer, "%" PRIu32, n);
@@ -92,3 +97,4 @@ static inline char *to_str(char *buffer, int16_t n) {
     sprintf(buffer, "%" PRId16, n);
     return buffer;
 }
+#pragma warning( pop )

--- a/test/outputs.h
+++ b/test/outputs.h
@@ -31,7 +31,7 @@ static inline char *to_str(char *buffer, int64_t n) {
 }
 
 template <typename _T>
-void print_serial(const _T &item) { Serial.print(item); }
+static inline void print_serial(const _T &item) { Serial.print(item); }
 
 template <>
 void print_serial(const uint64_t &item)
@@ -51,8 +51,11 @@ void print_serial(const int64_t &item)
 #define PRINT_INFO(item) print_serial(item)
 
 #else
+
+#if defined(_MSC_VER)
 #pragma warning( push )
 #pragma warning( disable : 4996 )
+#endif
 
 static inline char *to_str(char *buffer, uint64_t n) {
     sprintf(buffer, "%" PRIu64, n);
@@ -62,7 +65,10 @@ static inline char *to_str(char *buffer, int64_t n) {
     sprintf(buffer, "%" PRId64, n);
     return buffer;
 }
+
+#if defined(_MSC_VER)
 #pragma warning( pop )
+#endif
 
 #include <iostream>
 
@@ -77,8 +83,11 @@ static inline char *to_str(char *buffer, int64_t n) {
 #else
 #define PRINT_PROGRESS_MSG(item)
 #endif
+
+#if defined(_MSC_VER)
 #pragma warning( push )
 #pragma warning( disable : 4996 )
+#endif
 
 static inline char *to_str(char *buffer, uint32_t n) {
     sprintf(buffer, "%" PRIu32, n);
@@ -97,4 +106,6 @@ static inline char *to_str(char *buffer, int16_t n) {
     sprintf(buffer, "%" PRId16, n);
     return buffer;
 }
+#if defined(_MSC_VER)
 #pragma warning( pop )
+#endif

--- a/test/tester.cpp
+++ b/test/tester.cpp
@@ -18,6 +18,7 @@
 
 #include "DivideTest.h"
 #include "libdivide.h"
+#include "constexpr_test.h"
 
 // This is simply a regression test for #96: that the following all compile (and don't crash).
 static void test_primitives_compile() {
@@ -69,6 +70,7 @@ extern "C" int main(int argc, char *argv[]) {
     std::vector<bool> do_tests(6, default_do_test);
 
     test_primitives_compile();
+    test_constexpr();
 
     for (int i = 1; i < argc; i++) {
         const std::string arg(argv[i]);


### PR DESCRIPTION
Support compile time calculation of the `libdivide_[u16|s16|u32|s2|u64|s64](_branchfree)?_t` structs. E.g.

###   `constexpr auto constexprU64BF = libdivide::libdivide_u64_branchfree_gen_c(UINT64_MAX/123);`

This is good for performance and memory footprint.

**C++14 & up only**

### Implementation Notes
1. I could not make the existing generation functions constexpr without compromising their performance. As a result, a new family of functions has been introduced:  `libdivide_[u16|s16|u32|s2|u64|s64](_branchfree)?_gen_c`
2. Since asm & some compiler intrinsics are not constexpr compatible, the long division and leading zero count (E.g. `libdivide_64_div_32_to_32`, `libdivide_count_leading_zeros32`) functions had to be split up to provide software only implementations callable at compile time (E.g. `libdivide_64_div_32_to_32_software`, `libdivide_count_leading_zeros32_software`) .
3. Limiting copy/paste combined with constraints 1 & 2 required refactoring the structure generation code (E.g. `libdivide_internal_u32_gen`) to break out the `constexpr `compatible core algorithm (E.g. `libdivide_internal_u32_gen_gen`).
4. C++ only: in order to make the `constexpr` structs as useful as possible, I added '_do' overloads taking a const reference. The existing 'do' code is shared between overloads via a 'do_raw' function (x2 for branch free versions)
5. Manually maintaining all these function declarations is painful, so they are generated using macros (see `DECLARE_TYPE`). This also enforces consistency