### PR TITLE
feat: make sanitizer instrumentation optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ endif()
 
 option(LIBDIVIDE_BUILD_TESTS   "Build the test programs" "${MAIN_PROJECT}")
 option(LIBDIVIDE_BUILD_FUZZERS "Build the fuzzers (requires clang)" OFF)
+option(LIBDIVIDE_ENABLE_SANITIZERS "Enable sanitizer instrumentation" OFF)
 
 # By default we automatically enable vectors supported by
 # the host CPU. You may also set these explicitly to OFF or ON.
@@ -238,7 +239,9 @@ endif()
 add_library(libdivide INTERFACE)
 add_library(libdivide::libdivide ALIAS libdivide)
 
-include(CMakeSanitize)
+if (LIBDIVIDE_ENABLE_SANITIZERS)
+  include(CMakeSanitize)
+endif()
 
 target_compile_features(libdivide INTERFACE cxx_alias_templates)
 


### PR DESCRIPTION
prevent unintentionally injecting sanitizer flags into cmake release build (help with reproducibility across linux and macos)

relates to https://github.com/Homebrew/homebrew-core/pull/205519