### PR TITLE
Make __builtin_clz/__builtin_clzll constexpr to match gcc/clang

### DIFF
--- a/libdivide.h
+++ b/libdivide.h
@@ -28,9 +28,7 @@
     (defined(_MSVC_LANG) && (_MSVC_LANG >= 202002L))
 #include <limits.h>
 #include <type_traits>
-#define LIBDIVIDE_VC_CXX20 1
-#else
-#define LIBDIVIDE_VC_CXX20 0
+#define LIBDIVIDE_VC_CXX20
 #endif
 
 #if defined(LIBDIVIDE_SSE2)
@@ -160,7 +158,7 @@ namespace libdivide {
 #endif
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#if LIBDIVIDE_VC_CXX20
+#if defined(LIBDIVIDE_VC_CXX20)
 static LIBDIVIDE_CONSTEXPR int __builtin_clz(unsigned x) {
     if (std::is_constant_evaluated()) {
         for (int i = 0; i < sizeof(x) * CHAR_BIT; ++i) {
@@ -182,7 +180,7 @@ static LIBDIVIDE_INLINE int __builtin_clz(unsigned x) {
 #endif
 }
 
-#if LIBDIVIDE_VC_CXX20
+#if defined(LIBDIVIDE_VC_CXX20)
 static LIBDIVIDE_CONSTEXPR int __builtin_clzll(unsigned long long x) {
     if (std::is_constant_evaluated()) {
         for (int i = 0; i < sizeof(x) * CHAR_BIT; ++i) {

--- a/libdivide.h
+++ b/libdivide.h
@@ -162,14 +162,16 @@ namespace libdivide {
 #endif
 
 #if defined(_MSC_VER) && !defined(__clang__)
-static LIBDIVIDE_CONSTEXPR int __builtin_clz(unsigned x) {
 #if LIBDIVIDE_CXX20
+static LIBDIVIDE_CONSTEXPR int __builtin_clz(unsigned x) {
     if (LIBDIVIDE_CONSTEVAL) {
         for (int i = 0; i < sizeof(x) * CHAR_BIT; ++i) {
             if (x >> (sizeof(x) * CHAR_BIT - 1 - i)) return i;
         }
         return sizeof(x) * CHAR_BIT;
     }
+#else
+static LIBDIVIDE_INLINE int __builtin_clz(unsigned x) {
 #endif
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC)
     return (int)_CountLeadingZeros(x);
@@ -182,14 +184,16 @@ static LIBDIVIDE_CONSTEXPR int __builtin_clz(unsigned x) {
 #endif
 }
 
-static LIBDIVIDE_CONSTEXPR int __builtin_clzll(unsigned long long x) {
 #if LIBDIVIDE_CXX20
+static LIBDIVIDE_CONSTEXPR int __builtin_clzll(unsigned long long x) {
     if (LIBDIVIDE_CONSTEVAL) {
         for (int i = 0; i < sizeof(x) * CHAR_BIT; ++i) {
             if (x >> (sizeof(x) * CHAR_BIT - 1 - i)) return i;
         }
         return sizeof(x) * CHAR_BIT;
     }
+#else
+static LIBDIVIDE_INLINE int __builtin_clzll(unsigned long long x) {
 #endif
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC)
     return (int)_CountLeadingZeros64(x);

--- a/libdivide.h
+++ b/libdivide.h
@@ -24,15 +24,13 @@
 #include <stdlib.h>
 #endif
 
-#if (defined(__cplusplus) && (__cplusplus >= 202002L)) || \
+#if defined(_MSC_VER) && (defined(__cplusplus) && (__cplusplus >= 202002L)) || \
     (defined(_MSVC_LANG) && (_MSVC_LANG >= 202002L))
-#include <type_traits>
 #include <limits.h>
-#define LIBDIVIDE_CXX20 1
-#define LIBDIVIDE_CONSTEVAL (std::is_constant_evaluated())
+#include <type_traits>
+#define LIBDIVIDE_VC_CXX20 1
 #else
-#define LIBDIVIDE_CXX20 0
-#define LIBDIVIDE_CONSTEVAL 0
+#define LIBDIVIDE_VC_CXX20 0
 #endif
 
 #if defined(LIBDIVIDE_SSE2)
@@ -162,9 +160,9 @@ namespace libdivide {
 #endif
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#if LIBDIVIDE_CXX20
+#if LIBDIVIDE_VC_CXX20
 static LIBDIVIDE_CONSTEXPR int __builtin_clz(unsigned x) {
-    if (LIBDIVIDE_CONSTEVAL) {
+    if (std::is_constant_evaluated()) {
         for (int i = 0; i < sizeof(x) * CHAR_BIT; ++i) {
             if (x >> (sizeof(x) * CHAR_BIT - 1 - i)) return i;
         }
@@ -184,9 +182,9 @@ static LIBDIVIDE_INLINE int __builtin_clz(unsigned x) {
 #endif
 }
 
-#if LIBDIVIDE_CXX20
+#if LIBDIVIDE_VC_CXX20
 static LIBDIVIDE_CONSTEXPR int __builtin_clzll(unsigned long long x) {
-    if (LIBDIVIDE_CONSTEVAL) {
+    if (std::is_constant_evaluated()) {
         for (int i = 0; i < sizeof(x) * CHAR_BIT; ++i) {
             if (x >> (sizeof(x) * CHAR_BIT - 1 - i)) return i;
         }

--- a/libdivide.h
+++ b/libdivide.h
@@ -24,6 +24,16 @@
 #include <stdlib.h>
 #endif
 
+#if (defined(__cplusplus) && (__cplusplus >= 202002L)) || \
+    (defined(_MSVC_LANG) && (_MSVC_LANG >= 202002L))
+#include <type_traits>
+#define LIBDIVIDE_CXX20 1
+#define LIBDIVIDE_CONSTEVAL (std::is_constant_evaluated())
+#else
+#define LIBDIVIDE_CXX20 0
+#define LIBDIVIDE_CONSTEVAL 0
+#endif
+
 #if defined(LIBDIVIDE_SSE2)
 #include <emmintrin.h>
 #endif

--- a/libdivide.h
+++ b/libdivide.h
@@ -137,16 +137,14 @@
 
 #ifdef __cplusplus
 
-//for constexpr zero initialization,
-//c++11 might handle things ok,
-//but just limit to at least c++14 to ensure
-//we don't break anyone's code:
+// For constexpr zero initialization, c++11 might handle things ok,
+// but just limit to at least c++14 to ensure we don't break anyone's code:
 
 // for gcc and clang, use https://en.cppreference.com/w/cpp/feature_test#cpp_constexpr
 #if (defined(__GNUC__) || defined(__clang__)) && (__cpp_constexpr >= 201304L)
 #define LIBDIVIDE_CONSTEXPR constexpr LIBDIVIDE_INLINE
 
-// supposedly, MSVC might not implement feature test macros right (https://stackoverflow.com/questions/49316752/feature-test-macros-not-working-properly-in-visual-c)
+// Supposedly, MSVC might not implement feature test macros right (https://stackoverflow.com/questions/49316752/feature-test-macros-not-working-properly-in-visual-c)
 // so check that _MSVC_LANG corresponds to at least c++14, and _MSC_VER corresponds to at least VS 2017 15.0 (for extended constexpr support https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=msvc-170)
 #elif defined(_MSC_VER) && _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >=201402L
 #define LIBDIVIDE_CONSTEXPR constexpr LIBDIVIDE_INLINE

--- a/libdivide.h
+++ b/libdivide.h
@@ -27,6 +27,7 @@
 #if (defined(__cplusplus) && (__cplusplus >= 202002L)) || \
     (defined(_MSVC_LANG) && (_MSVC_LANG >= 202002L))
 #include <type_traits>
+#include <limits.h>
 #define LIBDIVIDE_CXX20 1
 #define LIBDIVIDE_CONSTEVAL (std::is_constant_evaluated())
 #else
@@ -164,10 +165,10 @@ namespace libdivide {
 static LIBDIVIDE_CONSTEXPR int __builtin_clz(unsigned x) {
 #if LIBDIVIDE_CXX20
     if (LIBDIVIDE_CONSTEVAL) {
-        for (int i = 0; i < sizeof(x) * 8; ++i) {
-            if (x >> (sizeof(x) * 8 - 1 - i)) return i;
+        for (int i = 0; i < sizeof(x) * CHAR_BIT; ++i) {
+            if (x >> (sizeof(x) * CHAR_BIT - 1 - i)) return i;
         }
-        return sizeof(x) * 8;
+        return sizeof(x) * CHAR_BIT;
     }
 #endif
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC)
@@ -184,10 +185,10 @@ static LIBDIVIDE_CONSTEXPR int __builtin_clz(unsigned x) {
 static LIBDIVIDE_CONSTEXPR int __builtin_clzll(unsigned long long x) {
 #if LIBDIVIDE_CXX20
     if (LIBDIVIDE_CONSTEVAL) {
-        for (int i = 0; i < sizeof(x) * 8; ++i) {
-            if (x >> (sizeof(x) * 8 - 1 - i)) return i;
+        for (int i = 0; i < sizeof(x) * CHAR_BIT; ++i) {
+            if (x >> (sizeof(x) * CHAR_BIT - 1 - i)) return i;
         }
-        return sizeof(x) * 8;
+        return sizeof(x) * CHAR_BIT;
     }
 #endif
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC)

--- a/libdivide.h
+++ b/libdivide.h
@@ -144,16 +144,16 @@
 
 // for gcc and clang, use https://en.cppreference.com/w/cpp/feature_test#cpp_constexpr
 #if (defined(__GNUC__) || defined(__clang__)) && (__cpp_constexpr >= 201304L)
-#define LIBDIVIDE_CONSTEXPR constexpr
+#define LIBDIVIDE_CONSTEXPR constexpr LIBDIVIDE_INLINE
 
 // supposedly, MSVC might not implement feature test macros right (https://stackoverflow.com/questions/49316752/feature-test-macros-not-working-properly-in-visual-c)
 // so check that _MSVC_LANG corresponds to at least c++14, and _MSC_VER corresponds to at least VS 2017 15.0 (for extended constexpr support https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=msvc-170)
 #elif defined(_MSC_VER) && _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >=201402L
-#define LIBDIVIDE_CONSTEXPR constexpr
+#define LIBDIVIDE_CONSTEXPR constexpr LIBDIVIDE_INLINE
 
 // in case some other obscure compiler has the right __cpp_constexpr :
 #elif defined(__cpp_constexpr) && __cpp_constexpr >= 201304L
-#define LIBDIVIDE_CONSTEXPR constexpr
+#define LIBDIVIDE_CONSTEXPR constexpr LIBDIVIDE_INLINE
 
 #else
 #define LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE

--- a/libdivide.h
+++ b/libdivide.h
@@ -136,6 +136,29 @@
 #endif
 
 #ifdef __cplusplus
+
+//for constexpr zero initialization,
+//c++11 might handle things ok,
+//but just limit to at least c++14 to ensure
+//we don't break anyone's code:
+
+// for gcc and clang, use https://en.cppreference.com/w/cpp/feature_test#cpp_constexpr
+#if (defined(__GNUC__) || defined(__clang__)) && (__cpp_constexpr >= 201304L)
+#define LIBDIVIDE_CONSTEXPR constexpr
+
+// supposedly, MSVC might not implement feature test macros right (https://stackoverflow.com/questions/49316752/feature-test-macros-not-working-properly-in-visual-c)
+// so check that _MSVC_LANG corresponds to at least c++14, and _MSC_VER corresponds to at least VS 2017 15.0 (for extended constexpr support https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=msvc-170)
+#elif defined(_MSC_VER) && _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >=201402L
+#define LIBDIVIDE_CONSTEXPR constexpr
+
+// in case some other obscure compiler has the right __cpp_constexpr :
+#elif defined(__cpp_constexpr) && __cpp_constexpr >= 201304L
+#define LIBDIVIDE_CONSTEXPR constexpr
+
+#else
+#define LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE
+#endif
+
 namespace libdivide {
 #endif
 
@@ -3024,28 +3047,6 @@ __m128i libdivide_s64_branchfree_do_vec128(
 /////////// C++ stuff
 
 #ifdef __cplusplus
-
-//for constexpr zero initialization,
-//c++11 might handle things ok,
-//but just limit to at least c++14 to ensure
-//we don't break anyone's code:
-
-// for gcc and clang, use https://en.cppreference.com/w/cpp/feature_test#cpp_constexpr
-#if (defined(__GNUC__) || defined(__clang__)) && (__cpp_constexpr >= 201304L)
-#define LIBDIVIDE_CONSTEXPR constexpr
-
-// supposedly, MSVC might not implement feature test macros right (https://stackoverflow.com/questions/49316752/feature-test-macros-not-working-properly-in-visual-c)
-// so check that _MSVC_LANG corresponds to at least c++14, and _MSC_VER corresponds to at least VS 2017 15.0 (for extended constexpr support https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=msvc-170)
-#elif defined(_MSC_VER) && _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >=201402L
-#define LIBDIVIDE_CONSTEXPR constexpr
-
-// in case some other obscure compiler has the right __cpp_constexpr :
-#elif defined(__cpp_constexpr) && __cpp_constexpr >= 201304L
-#define LIBDIVIDE_CONSTEXPR constexpr
-
-#else
-#define LIBDIVIDE_CONSTEXPR LIBDIVIDE_INLINE
-#endif
 
 enum Branching {
     BRANCHFULL,  // use branching algorithms

--- a/libdivide.h
+++ b/libdivide.h
@@ -161,7 +161,15 @@ namespace libdivide {
 #endif
 
 #if defined(_MSC_VER) && !defined(__clang__)
-static LIBDIVIDE_INLINE int __builtin_clz(unsigned x) {
+static LIBDIVIDE_CONSTEXPR int __builtin_clz(unsigned x) {
+#if LIBDIVIDE_CXX20
+    if (LIBDIVIDE_CONSTEVAL) {
+        for (int i = 0; i < sizeof(x) * 8; ++i) {
+            if (x >> (sizeof(x) * 8 - 1 - i)) return i;
+        }
+        return sizeof(x) * 8;
+    }
+#endif
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC)
     return (int)_CountLeadingZeros(x);
 #elif defined(__AVX2__) || defined(__LZCNT__)
@@ -173,7 +181,15 @@ static LIBDIVIDE_INLINE int __builtin_clz(unsigned x) {
 #endif
 }
 
-static LIBDIVIDE_INLINE int __builtin_clzll(unsigned long long x) {
+static LIBDIVIDE_CONSTEXPR int __builtin_clzll(unsigned long long x) {
+#if LIBDIVIDE_CXX20
+    if (LIBDIVIDE_CONSTEVAL) {
+        for (int i = 0; i < sizeof(x) * 8; ++i) {
+            if (x >> (sizeof(x) * 8 - 1 - i)) return i;
+        }
+        return sizeof(x) * 8;
+    }
+#endif
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC)
     return (int)_CountLeadingZeros64(x);
 #elif defined(_WIN64)


### PR DESCRIPTION
`__builtin_clz`/`__builtin_clzll` can be used in constexpr function with gcc/clang. This change makes them constexpr for msvc as well.
