### PR TITLE
Fix Assembler Warning: mnemonic suffix used with `div'

### DIFF
--- a/libdivide.h
+++ b/libdivide.h
@@ -514,7 +514,7 @@ static LIBDIVIDE_INLINE uint64_t libdivide_128_div_64_to_64(
     // it's not LIBDIVIDE_INLINEd.
 #if defined(LIBDIVIDE_X86_64) && defined(LIBDIVIDE_GCC_STYLE_ASM)
     uint64_t result;
-    __asm__("divq %[v]" : "=a"(result), "=d"(*r) : [v] "r"(den), "a"(numlo), "d"(numhi));
+    __asm__("div %[v]" : "=a"(result), "=d"(*r) : [v] "r"(den), "a"(numlo), "d"(numhi));
     return result;
 #else
     // We work in base 2**32.


### PR DESCRIPTION
This merge request fixes the following assembler warning that occurs when compiling using the upcoming GCC 15 on MinGW-w64/MSYS (Windows 11) for x86-64 CPUs:

```
C:\msys64\tmp\ccEHfp1X.s: Assembler messages:
C:\msys64\tmp\ccEHfp1X.s:7548: Warning: mnemonic suffix used with `div'
C:\msys64\tmp\ccEHfp1X.s:7548: Warning: NOTE: Such forms are deprecated and will be rejected by a future version of the assembler
```

Note that the warning is only emitted for ```__x86_64__``` but not for ```__i386__```. Hence `__asm__("divl ..."` can remain as is for the time being.