### PR TITLE
Fix CI MSVC sanitize builds

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -69,6 +69,7 @@ jobs:
           - windows-2019
         build_type:
           - Release
+          - Sanitize
         cpp_compiler:
           - clang-cl.exe
           - cl.exe
@@ -83,6 +84,10 @@ jobs:
           # clang-cl requires the toolset flag be set correctly 
           - cpp_compiler: clang-cl.exe
             toolset: ClangCL            
+        exclude:
+          # MSVC Clang toolchain fails sanitization
+          - cpp_compiler: clang-cl.exe
+            build_type: Sanitize
 
     env:
       output_folder: ${{github.workspace}}/build/
@@ -107,6 +112,7 @@ jobs:
         options: |
           LIBDIVIDE_BUILD_TESTS=ON
           CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          ${{ matrix.build_type == 'Sanitize' && 'LIBDIVIDE_ENABLE_SANITIZERS=ON' || '' }}
         build-args: --config ${{ matrix.build_type }}
 
     - name: Test


### PR DESCRIPTION
CI MSVC sanitize builds got previously broken by this commit: https://github.com/ridiculousfish/libdivide/commit/f026996e305f2c3ba72404e4c5525b4766a6532a