### PR TITLE
Only enable NEON on AArch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,10 +98,10 @@ if (LIBDIVIDE_BUILD_TESTS AND NOT CMAKE_CROSSCOMPILING)
         #include <arm_neon.h>
         int main()
         {
-            #if !defined(__ARM_NEON)
-                #error not ARM NEON CPU architecture
-            #endif
-            return 0;
+            int32x4_t a = vdupq_n_s32(0);
+            /* only available on AArch64 */
+            vuzp2q_s32(a, a);
+            return *(int *)&a;
         }"
         CPU_ARM_NEON)
     if (CPU_X86 OR CPU_ARM_NEON)
@@ -165,6 +165,8 @@ else()
     int main()
     {
         int32x4_t a = vdupq_n_s32(0);
+        /* only available on AArch64 */
+        vuzp2q_s32(a, a);
         return *(int *)&a;
     }")
     if (CMAKE_CROSSCOMPILING)


### PR DESCRIPTION
AArch32 also has NEON, but lacks some of the intrinsics needed. Explicitly check for presence of an AArch64-only intrinsic to make the NEON check fail on AArch32.

Fixes		#102