### PR TITLE
Preserve order of params when calling libdivide_mullhi

### DIFF
--- a/libdivide.h
+++ b/libdivide.h
@@ -1093,7 +1093,7 @@ uint32_t libdivide_u32_branchfree_recover(const struct libdivide_u32_branchfree_
     }
 }
 
-/////////// UINT64
+////////// UINT64
 
 static LIBDIVIDE_INLINE struct libdivide_u64_t libdivide_internal_u64_gen(
     uint64_t d, int branchfree) {
@@ -1268,7 +1268,7 @@ uint64_t libdivide_u64_branchfree_recover(const struct libdivide_u64_branchfree_
     }
 }
 
-/////////// SINT16
+////////// SINT16
 
 static LIBDIVIDE_INLINE struct libdivide_s16_t libdivide_internal_s16_gen(
     int16_t d, int branchfree) {
@@ -1444,7 +1444,7 @@ int16_t libdivide_s16_branchfree_recover(const struct libdivide_s16_branchfree_t
     return libdivide_s16_recover(&den);
 }
 
-/////////// SINT32
+////////// SINT32
 
 static LIBDIVIDE_INLINE struct libdivide_s32_t libdivide_internal_s32_gen(
     int32_t d, int branchfree) {
@@ -1617,7 +1617,7 @@ int32_t libdivide_s32_branchfree_recover(const struct libdivide_s32_branchfree_t
     return libdivide_s32_recover(&den);
 }
 
-///////////// SINT64
+////////// SINT64
 
 static LIBDIVIDE_INLINE struct libdivide_s64_t libdivide_internal_s64_gen(
     int64_t d, int branchfree) {
@@ -3062,7 +3062,7 @@ __m128i libdivide_s64_branchfree_do_vec128(
 
 #endif
 
-/////////// C++ stuff
+////////// C++ stuff
 
 #ifdef __cplusplus
 

--- a/libdivide.h
+++ b/libdivide.h
@@ -842,7 +842,7 @@ uint16_t libdivide_u16_do_raw(uint16_t numer, uint16_t magic, uint8_t more) {
     if (!magic) {
         return numer >> more;
     } else {
-        uint16_t q = libdivide_mullhi_u16(magic, numer);
+        uint16_t q = libdivide_mullhi_u16(numer, magic);
         if (more & LIBDIVIDE_ADD_MARKER) {
             uint16_t t = ((numer - q) >> 1) + q;
             return t >> (more & LIBDIVIDE_16_SHIFT_MASK);
@@ -860,7 +860,7 @@ uint16_t libdivide_u16_do(uint16_t numer, const struct libdivide_u16_t *denom) {
 
 uint16_t libdivide_u16_branchfree_do(
     uint16_t numer, const struct libdivide_u16_branchfree_t *denom) {
-    uint16_t q = libdivide_mullhi_u16(denom->magic, numer);
+    uint16_t q = libdivide_mullhi_u16(numer, denom->magic);
     uint16_t t = ((numer - q) >> 1) + q;
     return t >> denom->more;
 }
@@ -1003,7 +1003,7 @@ uint32_t libdivide_u32_do_raw(uint32_t numer, uint32_t magic, uint8_t more) {
     if (!magic) {
         return numer >> more;
     } else {
-        uint32_t q = libdivide_mullhi_u32(magic, numer);
+        uint32_t q = libdivide_mullhi_u32(numer, magic);
         if (more & LIBDIVIDE_ADD_MARKER) {
             uint32_t t = ((numer - q) >> 1) + q;
             return t >> (more & LIBDIVIDE_32_SHIFT_MASK);
@@ -1021,7 +1021,7 @@ uint32_t libdivide_u32_do(uint32_t numer, const struct libdivide_u32_t *denom) {
 
 uint32_t libdivide_u32_branchfree_do(
     uint32_t numer, const struct libdivide_u32_branchfree_t *denom) {
-    uint32_t q = libdivide_mullhi_u32(denom->magic, numer);
+    uint32_t q = libdivide_mullhi_u32(numer, denom->magic);
     uint32_t t = ((numer - q) >> 1) + q;
     return t >> denom->more;
 }
@@ -1166,7 +1166,7 @@ uint64_t libdivide_u64_do_raw(uint64_t numer, uint64_t magic, uint8_t more) {
    if (!magic) {
         return numer >> more;
     } else {
-        uint64_t q = libdivide_mullhi_u64(magic, numer);
+        uint64_t q = libdivide_mullhi_u64(numer, magic);
         if (more & LIBDIVIDE_ADD_MARKER) {
             uint64_t t = ((numer - q) >> 1) + q;
             return t >> (more & LIBDIVIDE_64_SHIFT_MASK);
@@ -1184,7 +1184,7 @@ uint64_t libdivide_u64_do(uint64_t numer, const struct libdivide_u64_t *denom) {
 
 uint64_t libdivide_u64_branchfree_do(
     uint64_t numer, const struct libdivide_u64_branchfree_t *denom) {
-    uint64_t q = libdivide_mullhi_u64(denom->magic, numer);
+    uint64_t q = libdivide_mullhi_u64(numer, denom->magic);
     uint64_t t = ((numer - q) >> 1) + q;
     return t >> denom->more;
 }
@@ -1361,7 +1361,7 @@ int16_t libdivide_s16_do_raw(int16_t numer, int16_t magic, uint8_t more) {
         q = (q ^ sign) - sign;
         return q;
     } else {
-        uint16_t uq = (uint16_t)libdivide_mullhi_s16(magic, numer);
+        uint16_t uq = (uint16_t)libdivide_mullhi_s16(numer, magic);
         if (more & LIBDIVIDE_ADD_MARKER) {
             // must be arithmetic shift and then sign extend
             int16_t sign = (int8_t)more >> 7;
@@ -1386,7 +1386,7 @@ int16_t libdivide_s16_branchfree_do(int16_t numer, const struct libdivide_s16_br
     // must be arithmetic shift and then sign extend
     int16_t sign = (int8_t)more >> 7;
     int16_t magic = denom->magic;
-    int16_t q = libdivide_mullhi_s16(magic, numer);
+    int16_t q = libdivide_mullhi_s16(numer, magic);
     q += numer;
 
     // If q is non-negative, we have nothing to do
@@ -1534,7 +1534,7 @@ int32_t libdivide_s32_do_raw(int32_t numer, int32_t magic, uint8_t more) {
         q = (q ^ sign) - sign;
         return q;
     } else {
-        uint32_t uq = (uint32_t)libdivide_mullhi_s32(magic, numer);
+        uint32_t uq = (uint32_t)libdivide_mullhi_s32(numer, magic);
         if (more & LIBDIVIDE_ADD_MARKER) {
             // must be arithmetic shift and then sign extend
             int32_t sign = (int8_t)more >> 7;
@@ -1559,7 +1559,7 @@ int32_t libdivide_s32_branchfree_do(int32_t numer, const struct libdivide_s32_br
     // must be arithmetic shift and then sign extend
     int32_t sign = (int8_t)more >> 7;
     int32_t magic = denom->magic;
-    int32_t q = libdivide_mullhi_s32(magic, numer);
+    int32_t q = libdivide_mullhi_s32(numer, magic);
     q += numer;
 
     // If q is non-negative, we have nothing to do
@@ -1708,7 +1708,7 @@ int64_t libdivide_s64_do_raw(int64_t numer, int64_t magic, uint8_t more) {
         q = (q ^ sign) - sign;
         return q;
     } else {
-        uint64_t uq = (uint64_t)libdivide_mullhi_s64(magic, numer);
+        uint64_t uq = (uint64_t)libdivide_mullhi_s64(numer, magic);
         if (more & LIBDIVIDE_ADD_MARKER) {
             // must be arithmetic shift and then sign extend
             int64_t sign = (int8_t)more >> 7;
@@ -1733,7 +1733,7 @@ int64_t libdivide_s64_branchfree_do(int64_t numer, const struct libdivide_s64_br
     // must be arithmetic shift and then sign extend
     int64_t sign = (int8_t)more >> 7;
     int64_t magic = denom->magic;
-    int64_t q = libdivide_mullhi_s64(magic, numer);
+    int64_t q = libdivide_mullhi_s64(numer, magic);
     q += numer;
 
     // If q is non-negative, we have nothing to do.


### PR DESCRIPTION
This change improves code generation in 32-bit builds (shorter code, uses less stack).
