### PR TITLE
Update libdivide.h to support `-ffreestanding` targets

### DIFF
--- a/libdivide.h
+++ b/libdivide.h
@@ -19,7 +19,7 @@
 
 #include <stdint.h>
 
-#if !defined(__AVR__)
+#if !defined(__AVR__) && __STDC_HOSTED__ != 0
 #include <stdio.h>
 #include <stdlib.h>
 #endif
@@ -109,7 +109,7 @@
 #endif
 #endif
 
-#if defined(__AVR__)
+#if defined(__AVR__) || __STDC_HOSTED__ == 0
 #define LIBDIVIDE_ERROR(msg)
 #else
 #define LIBDIVIDE_ERROR(msg)                                                                     \
@@ -119,7 +119,7 @@
     } while (0)
 #endif
 
-#if defined(LIBDIVIDE_ASSERTIONS_ON) && !defined(__AVR__)
+#if defined(LIBDIVIDE_ASSERTIONS_ON) && !defined(__AVR__) && __STDC_HOSTED__ != 0
 #define LIBDIVIDE_ASSERT(x)                                                           \
     do {                                                                              \
         if (!(x)) {                                                                   \


### PR DESCRIPTION
Simply check for the value of the `__STDC_HOSTED__` macro before including `<stdlib.h>` or `<stdio.h>` and others.

Moreover, as an idea for future changes, you could also add some checks for user-provided `LIBDIVIDE_{ERROR|ASSERT}`, as printing to the screen and aborting the program is not always a good thing to do anyways (and is sometimes not even possible, in the case of a freestanding environment)