### PR TITLE
Fix GCC 15 compiler errors

### DIFF
--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -16,7 +16,7 @@
 
 #include <string.h>
 
-extern "C" int main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
     // Disable printf buffering.
     // This is mainly required for Windows.
     setbuf(stdout, NULL);

--- a/test/benchmark_branchfree.cpp
+++ b/test/benchmark_branchfree.cpp
@@ -171,7 +171,7 @@ void usage() {
               << std::endl;
 }
 
-extern "C" int main(int argc, const char* argv[]) {
+int main(int argc, const char* argv[]) {
     tasks_t tasks = 0;
 
     for (int i = 1; i < argc; i++) {

--- a/test/fast_div_generator.cpp
+++ b/test/fast_div_generator.cpp
@@ -147,7 +147,7 @@ void print_disclaimer()
                 << "// See " << __FILE__ << "\n";
 }
 
-extern "C" int main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
     if (argc!=3) {
         std::cout
                 << "Usage: fast_div_generator [DATATYPE] [STYLE]\n"

--- a/test/tester.cpp
+++ b/test/tester.cpp
@@ -64,7 +64,7 @@ void launch_test_thread(std::vector<std::thread> &test_threads) {
     test_threads.emplace_back(run_test<_IntT>);
 }
 
-extern "C" int main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
     bool default_do_test = (argc <= 1);
     std::vector<bool> do_tests(6, default_do_test);
 


### PR DESCRIPTION
`extern "c" int main()` is not allowed in C++, [the standard](https://isocpp.org/files/papers/N4860.pdf) says that:

> The main function shall not be declared with a linkage-specification (9.11). A program that declares a variable main at global scope, or that declares a function main at global scope attached to a named module, or that declares the name main with C language linkage (in any namespace) is ill-formed.

The checking of the C++ language standard has become stricter since GCC 15, so test code will report errors at compile time:
<img width="1183" alt="Snipaste_2025-05-17_16-27-24" src="https://github.com/user-attachments/assets/186d0e62-d087-4065-be43-aa112a1a0a4c" />

Fix this kind of error by removing illegal `extern "C"` declares.