### PR TITLE
Add ARM SVE support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(LIBDIVIDE_SSE2  AUTO CACHE STRING  "Enable SSE2 vector instructions")
 set(LIBDIVIDE_AVX2  AUTO CACHE STRING  "Enable AVX2 vector instructions")
 set(LIBDIVIDE_AVX512 AUTO CACHE STRING "Enable AVX512 vector instructions")
 set(LIBDIVIDE_NEON AUTO CACHE STRING "Enable ARM NEON vector instructions")
+set(LIBDIVIDE_SVE  AUTO CACHE STRING  "Enable ARM SVE vector instructions")
 
 # By default enable release mode ###############################
 
@@ -75,7 +76,7 @@ if (WARN_VEC_CONVERSIONS)
 endif()
 
 
-# Check if x86/x64 CPU  ########################################
+# Check native CPU family ######################################
 
 # Note that check_cxx_source_runs() must not be used when
 # cross-compiling otherwise the following error will occur:
@@ -176,6 +177,23 @@ else()
     endif()
 endif()
 
+# SVE
+if (NOT LIBDIVIDE_SVE STREQUAL "AUTO")
+    set(LIBDIVIDE_SVE_ENABLED "${LIBDIVIDE_SVE}")
+else()
+    set(SVE_TEST "
+    #include <arm_sve.h>
+    int main()
+    {
+        return svcntd() == 0;
+    }")
+    if (CMAKE_CROSSCOMPILING)
+        check_cxx_source_compiles("${SVE_TEST}" LIBDIVIDE_SVE_ENABLED)
+    else()
+        check_cxx_source_runs("${SVE_TEST}" LIBDIVIDE_SVE_ENABLED)
+    endif()
+endif()
+
 # AVX512
 if (NOT LIBDIVIDE_AVX512 STREQUAL "AUTO")
     set(LIBDIVIDE_AVX512_ENABLED "${LIBDIVIDE_AVX512}")
@@ -225,6 +243,9 @@ cmake_pop_check_state()
 set(LIBDIVIDE_VECTOR_EXT "")
 if(LIBDIVIDE_NEON_ENABLED)
     list(APPEND LIBDIVIDE_VECTOR_EXT "LIBDIVIDE_NEON")
+endif()
+if(LIBDIVIDE_SVE_ENABLED)
+    list(APPEND LIBDIVIDE_VECTOR_EXT "LIBDIVIDE_SVE")
 endif()
 if(LIBDIVIDE_AVX512_ENABLED)
     list(APPEND LIBDIVIDE_VECTOR_EXT "LIBDIVIDE_AVX512")

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ```libdivide.h```  is a header-only C/C++ library for optimizing integer division. Integer division is one of the slowest instructions on most CPUs e.g. on current x64 CPUs a 64-bit integer division has a latency of up to 90 clock cycles whereas a multiplication has a latency of only 3 clock cycles. libdivide allows you to replace expensive integer division instructions by a sequence of shift, add and multiply instructions that will calculate the integer division much faster.
 
-On current CPUs you can get a **speedup of up to 10x** for 64-bit integer division and a speedup of up to to 5x for 32-bit integer division when using libdivide. libdivide also supports [SSE2](https://en.wikipedia.org/wiki/SSE2), [AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) and [AVX512](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) vector division which provides an even larger speedup. You can test how much speedup you can achieve on your CPU using the [benchmark](#benchmark-program) program.
+On current CPUs you can get a **speedup of up to 10x** for 64-bit integer division and a speedup of up to 5x for 32-bit integer division when using libdivide. libdivide also supports [SSE2](https://en.wikipedia.org/wiki/SSE2), [AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions), [AVX512](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions), NEON, and SVE vector division, which can provide an even larger speedup. You can test how much speedup you can achieve on your CPU using the [benchmark](#benchmark-program) program.
 
 libdivide is compatible with 8-bit microcontrollers, such as the AVR series: [the CI build includes a AtMega2560 target](test/avr/readme.md). Since low end hardware such as this often do not include a hardware divider, libdivide is particularly useful. In addition to the runtime [C](doc/C-API.md) & [C++](doc/CPP-API.md) APIs, a set of [predefined macros](constant_fast_div.h) and [templates](constant_fast_div.hpp) is included to speed up division by 16-bit constants: division by a 16-bit constant is [not optimized by avr-gcc on 8-bit systems](https://stackoverflow.com/questions/47994933/why-doesnt-gcc-or-clang-on-arm-use-division-by-invariant-integers-using-multip). 
 
@@ -106,9 +106,9 @@ Caveats of branchfree divider:
 ## Vector division
 
 libdivide supports [SSE2](https://en.wikipedia.org/wiki/SSE2),
-[AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) and
-[AVX512](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions)
-vector division on x86 and x64 CPUs. In the example below we divide the packed 32-bit integers inside an AVX512 vector using libdivide. libdivide supports 32-bit and 64-bit vector division for both signed and unsigned integers.
+[AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions),
+[AVX512](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions),
+NEON, and SVE vector division. In the example below we divide the packed 32-bit integers inside an AVX512 vector using libdivide. libdivide supports 16-bit, 32-bit, and 64-bit vector division for both signed and unsigned integers.
 
 ```C++
 #include "libdivide.h"
@@ -129,6 +129,7 @@ Note that you need to define one of macros below to enable vector division:
 * ```LIBDIVIDE_AVX2```
 * ```LIBDIVIDE_AVX512```
 * ```LIBDIVIDE_NEON```
+* ```LIBDIVIDE_SVE```
 
 ## Performance Tips
 
@@ -138,9 +139,9 @@ Note that you need to define one of macros below to enable vector division:
   choose the one that performs best. The branchfree divider is more likely to get auto
   vectorized by the compiler (if you compile with e.g. ```-march=native```). But don't forget
   that the unsigned branchfree divider cannot be 1.
-* Vector division is much faster for 32-bit than for 64-bit. This is because there are
-  currently no vector multiplication instructions on x86 to efficiently calculate
-  64-bit * 64-bit to 128-bit. 
+* On x86, vector division is much faster for 32-bit than for 64-bit. This is because
+  there are currently no vector multiplication instructions on x86 to efficiently
+  calculate 64-bit * 64-bit to 128-bit.
 
 ## Build instructions
 

--- a/doc/C-API.md
+++ b/doc/C-API.md
@@ -62,6 +62,29 @@ int64x2_t libdivide_s64_branchfree_do_vec128(int64x2_t numers, const struct libd
 
 You need to define ```LIBDIVIDE_NEON``` to enable NEON vector division.
 
+## libdivide SVE vector division
+
+```C
+/* libdivide SVE division */
+svuint16_t libdivide_u16_do_sve(svuint16_t numers, const struct libdivide_u16_t *denom);
+svint16_t libdivide_s16_do_sve(svint16_t numers, const struct libdivide_s16_t *denom);
+svuint32_t libdivide_u32_do_sve(svuint32_t numers, const struct libdivide_u32_t *denom);
+svint32_t libdivide_s32_do_sve(svint32_t numers, const struct libdivide_s32_t *denom);
+svuint64_t libdivide_u64_do_sve(svuint64_t numers, const struct libdivide_u64_t *denom);
+svint64_t libdivide_s64_do_sve(svint64_t numers, const struct libdivide_s64_t *denom);
+
+/* libdivide SVE branchfree division */
+svuint16_t libdivide_u16_branchfree_do_sve(svuint16_t numers, const struct libdivide_u16_branchfree_t *denom);
+svint16_t libdivide_s16_branchfree_do_sve(svint16_t numers, const struct libdivide_s16_branchfree_t *denom);
+svuint32_t libdivide_u32_branchfree_do_sve(svuint32_t numers, const struct libdivide_u32_branchfree_t *denom);
+svint32_t libdivide_s32_branchfree_do_sve(svint32_t numers, const struct libdivide_s32_branchfree_t *denom);
+svuint64_t libdivide_u64_branchfree_do_sve(svuint64_t numers, const struct libdivide_u64_branchfree_t *denom);
+svint64_t libdivide_s64_branchfree_do_sve(svint64_t numers, const struct libdivide_s64_branchfree_t *denom);
+```
+
+You need to define ```LIBDIVIDE_SVE``` and compile for a target with Arm SVE
+support to enable SVE vector division.
+
 ## libdivide SSE2 vector division
 
 ```C

--- a/doc/CPP-API.md
+++ b/doc/CPP-API.md
@@ -77,8 +77,53 @@ template <Branching ALGO>
 int64x2_t operator/=(int64x2_t &n, const divider<int64_t, ALGO> &div)
 ```
 
-You need to define ```LIBDIVIDE_NEON``` to enable SSE2 vector division.
+You need to define ```LIBDIVIDE_NEON``` to enable NEON vector division.
 
+## SVE vector division
+
+```C++
+// Overload of operator /
+template <Branching ALGO>
+svuint16_t operator/(svuint16_t n, const divider<uint16_t, ALGO> &div)
+
+template <Branching ALGO>
+svint16_t operator/(svint16_t n, const divider<int16_t, ALGO> &div)
+
+template <Branching ALGO>
+svuint32_t operator/(svuint32_t n, const divider<uint32_t, ALGO> &div)
+
+template <Branching ALGO>
+svint32_t operator/(svint32_t n, const divider<int32_t, ALGO> &div)
+
+template <Branching ALGO>
+svuint64_t operator/(svuint64_t n, const divider<uint64_t, ALGO> &div)
+
+template <Branching ALGO>
+svint64_t operator/(svint64_t n, const divider<int64_t, ALGO> &div)
+
+
+// Overload of operator /=
+template <Branching ALGO>
+svuint16_t operator/=(svuint16_t &n, const divider<uint16_t, ALGO> &div)
+
+template <Branching ALGO>
+svint16_t operator/=(svint16_t &n, const divider<int16_t, ALGO> &div)
+
+template <Branching ALGO>
+svuint32_t operator/=(svuint32_t &n, const divider<uint32_t, ALGO> &div)
+
+template <Branching ALGO>
+svint32_t operator/=(svint32_t &n, const divider<int32_t, ALGO> &div)
+
+template <Branching ALGO>
+svuint64_t operator/=(svuint64_t &n, const divider<uint64_t, ALGO> &div)
+
+template <Branching ALGO>
+svint64_t operator/=(svint64_t &n, const divider<int64_t, ALGO> &div)
+```
+
+You need to define ```LIBDIVIDE_SVE``` and compile for a target with Arm SVE
+support to enable SVE vector division.
 
 ## SSE2 vector division
 

--- a/libdivide.h
+++ b/libdivide.h
@@ -44,6 +44,10 @@
 #include <arm_neon.h>
 #endif
 
+#if defined(LIBDIVIDE_SVE)
+#include <arm_sve.h>
+#endif
+
 // Clang-cl prior to Visual Studio 2022 doesn't include __umulh/__mulh intrinsics
 #if defined(_MSC_VER) && (!defined(__clang__) || _MSC_VER > 1930) && \
     (defined(_M_X64) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC))
@@ -2092,6 +2096,343 @@ int64x2_t libdivide_s64_branchfree_do_vec128(
 
 #endif
 
+#if defined(LIBDIVIDE_SVE)
+
+static LIBDIVIDE_INLINE svuint16_t libdivide_u16_do_sve(
+    svuint16_t numers, const struct libdivide_u16_t *denom);
+static LIBDIVIDE_INLINE svint16_t libdivide_s16_do_sve(
+    svint16_t numers, const struct libdivide_s16_t *denom);
+static LIBDIVIDE_INLINE svuint32_t libdivide_u32_do_sve(
+    svuint32_t numers, const struct libdivide_u32_t *denom);
+static LIBDIVIDE_INLINE svint32_t libdivide_s32_do_sve(
+    svint32_t numers, const struct libdivide_s32_t *denom);
+static LIBDIVIDE_INLINE svuint64_t libdivide_u64_do_sve(
+    svuint64_t numers, const struct libdivide_u64_t *denom);
+static LIBDIVIDE_INLINE svint64_t libdivide_s64_do_sve(
+    svint64_t numers, const struct libdivide_s64_t *denom);
+
+static LIBDIVIDE_INLINE svuint16_t libdivide_u16_branchfree_do_sve(
+    svuint16_t numers, const struct libdivide_u16_branchfree_t *denom);
+static LIBDIVIDE_INLINE svint16_t libdivide_s16_branchfree_do_sve(
+    svint16_t numers, const struct libdivide_s16_branchfree_t *denom);
+static LIBDIVIDE_INLINE svuint32_t libdivide_u32_branchfree_do_sve(
+    svuint32_t numers, const struct libdivide_u32_branchfree_t *denom);
+static LIBDIVIDE_INLINE svint32_t libdivide_s32_branchfree_do_sve(
+    svint32_t numers, const struct libdivide_s32_branchfree_t *denom);
+static LIBDIVIDE_INLINE svuint64_t libdivide_u64_branchfree_do_sve(
+    svuint64_t numers, const struct libdivide_u64_branchfree_t *denom);
+static LIBDIVIDE_INLINE svint64_t libdivide_s64_branchfree_do_sve(
+    svint64_t numers, const struct libdivide_s64_branchfree_t *denom);
+
+//////// Internal Utility Functions
+
+// logical shift right
+static LIBDIVIDE_INLINE svuint16_t libdivide_u16_sve_srl(svuint16_t v, uint8_t amt) {
+    return svlsr_wide_u16_x(svptrue_b16(), v, svdup_n_u64(amt));
+}
+
+static LIBDIVIDE_INLINE svuint32_t libdivide_u32_sve_srl(svuint32_t v, uint8_t amt) {
+    return svlsr_wide_u32_x(svptrue_b32(), v, svdup_n_u64(amt));
+}
+
+static LIBDIVIDE_INLINE svuint64_t libdivide_u64_sve_srl(svuint64_t v, uint8_t amt) {
+    return svlsr_n_u64_x(svptrue_b64(), v, amt);
+}
+
+// arithmetic shift right
+static LIBDIVIDE_INLINE svint16_t libdivide_s16_sve_sra(svint16_t v, uint8_t amt) {
+    return svasr_wide_s16_x(svptrue_b16(), v, svdup_n_u64(amt));
+}
+
+static LIBDIVIDE_INLINE svint32_t libdivide_s32_sve_sra(svint32_t v, uint8_t amt) {
+    return svasr_wide_s32_x(svptrue_b32(), v, svdup_n_u64(amt));
+}
+
+static LIBDIVIDE_INLINE svint64_t libdivide_s64_sve_sra(svint64_t v, uint8_t amt) {
+    return svasr_n_s64_x(svptrue_b64(), v, amt);
+}
+
+// unsigned halving subtract: (x - y) >> 1
+// SVE2 has svhsub_u*_x() for this operation, could be useful later
+static LIBDIVIDE_INLINE svuint16_t libdivide_u16_sve_hsub(svuint16_t x, svuint16_t y) {
+    svbool_t pg = svptrue_b16();
+    return svlsr_n_u16_x(pg, svsub_u16_x(pg, x, y), 1);
+}
+
+static LIBDIVIDE_INLINE svuint32_t libdivide_u32_sve_hsub(svuint32_t x, svuint32_t y) {
+    svbool_t pg = svptrue_b32();
+    return svlsr_n_u32_x(pg, svsub_u32_x(pg, x, y), 1);
+}
+
+static LIBDIVIDE_INLINE svuint64_t libdivide_u64_sve_hsub(svuint64_t x, svuint64_t y) {
+    svbool_t pg = svptrue_b64();
+    return svlsr_n_u64_x(pg, svsub_u64_x(pg, x, y), 1);
+}
+
+// sign mask: 0 for non-negative lanes, -1 for negative lanes
+static LIBDIVIDE_INLINE svint16_t libdivide_s16_sve_signbits(svint16_t v) {
+    return svasr_n_s16_x(svptrue_b16(), v, 15);
+}
+
+static LIBDIVIDE_INLINE svint32_t libdivide_s32_sve_signbits(svint32_t v) {
+    return svasr_n_s32_x(svptrue_b32(), v, 31);
+}
+
+static LIBDIVIDE_INLINE svint64_t libdivide_s64_sve_signbits(svint64_t v) {
+    return svasr_n_s64_x(svptrue_b64(), v, 63);
+}
+
+////////// UINT16
+
+svuint16_t libdivide_u16_do_sve(svuint16_t numers, const struct libdivide_u16_t *denom) {
+    svbool_t pg = svptrue_b16();
+    uint8_t more = denom->more;
+
+    // power of 2 path
+    if (!denom->magic) {
+        return libdivide_u16_sve_srl(numers, more);
+    }
+
+    svuint16_t q = svmulh_n_u16_x(pg, numers, denom->magic);
+    if (more & LIBDIVIDE_ADD_MARKER) {
+        // t = ((numers - q) >> 1) + q
+        uint8_t shift = more & LIBDIVIDE_16_SHIFT_MASK;
+        svuint16_t t = svadd_u16_x(pg, libdivide_u16_sve_hsub(numers, q), q);
+        return libdivide_u16_sve_srl(t, shift);
+    }
+
+    return libdivide_u16_sve_srl(q, more);
+}
+
+svuint16_t libdivide_u16_branchfree_do_sve(
+    svuint16_t numers, const struct libdivide_u16_branchfree_t *denom) {
+    svbool_t pg = svptrue_b16();
+    // branchfree always uses the add-marker correction
+    svuint16_t q = svmulh_n_u16_x(pg, numers, denom->magic);
+    svuint16_t t = svadd_u16_x(pg, libdivide_u16_sve_hsub(numers, q), q);
+    return libdivide_u16_sve_srl(t, denom->more);
+}
+
+////////// UINT32
+
+svuint32_t libdivide_u32_do_sve(svuint32_t numers, const struct libdivide_u32_t *denom) {
+    svbool_t pg = svptrue_b32();
+    uint8_t more = denom->more;
+
+    // power of 2 path
+    if (!denom->magic) {
+        return libdivide_u32_sve_srl(numers, more);
+    }
+
+    svuint32_t q = svmulh_n_u32_x(pg, numers, denom->magic);
+    if (more & LIBDIVIDE_ADD_MARKER) {
+        // t = ((numers - q) >> 1) + q
+        uint8_t shift = more & LIBDIVIDE_32_SHIFT_MASK;
+        svuint32_t t = svadd_u32_x(pg, libdivide_u32_sve_hsub(numers, q), q);
+        return libdivide_u32_sve_srl(t, shift);
+    }
+
+    return libdivide_u32_sve_srl(q, more);
+}
+
+svuint32_t libdivide_u32_branchfree_do_sve(
+    svuint32_t numers, const struct libdivide_u32_branchfree_t *denom) {
+    svbool_t pg = svptrue_b32();
+    // branchfree always uses the add-marker correction
+    svuint32_t q = svmulh_n_u32_x(pg, numers, denom->magic);
+    svuint32_t t = svadd_u32_x(pg, libdivide_u32_sve_hsub(numers, q), q);
+    return libdivide_u32_sve_srl(t, denom->more);
+}
+
+////////// UINT64
+
+svuint64_t libdivide_u64_do_sve(svuint64_t numers, const struct libdivide_u64_t *denom) {
+    svbool_t pg = svptrue_b64();
+    uint8_t more = denom->more;
+
+    // power of 2 path
+    if (!denom->magic) {
+        return libdivide_u64_sve_srl(numers, more);
+    }
+
+    svuint64_t q = svmulh_n_u64_x(pg, numers, denom->magic);
+    if (more & LIBDIVIDE_ADD_MARKER) {
+        // t = ((numers - q) >> 1) + q
+        uint8_t shift = more & LIBDIVIDE_64_SHIFT_MASK;
+        svuint64_t t = svadd_u64_x(pg, libdivide_u64_sve_hsub(numers, q), q);
+        return libdivide_u64_sve_srl(t, shift);
+    }
+
+    return libdivide_u64_sve_srl(q, more);
+}
+
+svuint64_t libdivide_u64_branchfree_do_sve(
+    svuint64_t numers, const struct libdivide_u64_branchfree_t *denom) {
+    svbool_t pg = svptrue_b64();
+    // branchfree always uses the add-marker correction
+    svuint64_t q = svmulh_n_u64_x(pg, numers, denom->magic);
+    svuint64_t t = svadd_u64_x(pg, libdivide_u64_sve_hsub(numers, q), q);
+    return libdivide_u64_sve_srl(t, denom->more);
+}
+
+////////// SINT16
+
+svint16_t libdivide_s16_do_sve(svint16_t numers, const struct libdivide_s16_t *denom) {
+    svbool_t pg = svptrue_b16();
+    uint8_t more = denom->more;
+
+    // power of 2 path
+    if (!denom->magic) {
+        uint8_t shift = more & LIBDIVIDE_16_SHIFT_MASK;
+        uint16_t mask = ((uint16_t)1 << shift) - 1;
+
+        // q = (numers + ((numers < 0) ? mask : 0)) >> shift
+        svint16_t q = svadd_s16_x(pg, numers,
+            svand_s16_x(pg, libdivide_s16_sve_signbits(numers), svdup_n_s16((int16_t)mask)));
+        q = libdivide_s16_sve_sra(q, shift);
+
+        // flip sign if divisor was negative
+        svint16_t sign = svdup_n_s16((int8_t)more >> 7);
+        return svsub_s16_x(pg, sveor_s16_x(pg, q, sign), sign);
+    }
+
+    // magic multiply-high path
+    svint16_t q = svmulh_n_s16_x(pg, numers, denom->magic);
+    if (more & LIBDIVIDE_ADD_MARKER) {
+        // add numers back, adjusted for divisor sign
+        svint16_t sign = svdup_n_s16((int8_t)more >> 7);
+        q = svadd_s16_x(pg, q, svsub_s16_x(pg, sveor_s16_x(pg, numers, sign), sign));
+    }
+    q = libdivide_s16_sve_sra(q, more & LIBDIVIDE_16_SHIFT_MASK);
+    // round toward zero
+    return svsub_s16_x(pg, q, libdivide_s16_sve_signbits(q));
+}
+
+svint16_t libdivide_s16_branchfree_do_sve(
+    svint16_t numers, const struct libdivide_s16_branchfree_t *denom) {
+    svbool_t pg = svptrue_b16();
+    int16_t magic = denom->magic;
+    uint8_t more = denom->more;
+    uint8_t shift = more & LIBDIVIDE_16_SHIFT_MASK;
+    svint16_t sign = svdup_n_s16((int8_t)more >> 7);
+    // branchfree starts with q = mullhi(numers, magic) + numers
+    svint16_t q = svmulh_n_s16_x(pg, numers, magic);
+    q = svadd_s16_x(pg, q, numers);
+    uint32_t is_power_of_2 = (magic == 0);
+    uint32_t mask = ((uint32_t)1 << shift) - is_power_of_2;
+    svint16_t mask_vec = svdup_n_s16((int16_t)mask);
+    // negative q needs a bias before arithmetic shift
+    q = svadd_s16_x(pg, q, svand_s16_x(pg, libdivide_s16_sve_signbits(q), mask_vec));
+    q = libdivide_s16_sve_sra(q, shift);
+    return svsub_s16_x(pg, sveor_s16_x(pg, q, sign), sign);
+}
+
+////////// SINT32
+
+svint32_t libdivide_s32_do_sve(svint32_t numers, const struct libdivide_s32_t *denom) {
+    svbool_t pg = svptrue_b32();
+    uint8_t more = denom->more;
+
+    // power of 2 path
+    if (!denom->magic) {
+        uint8_t shift = more & LIBDIVIDE_32_SHIFT_MASK;
+        uint32_t mask = ((uint32_t)1 << shift) - 1;
+
+        // q = (numers + ((numers < 0) ? mask : 0)) >> shift
+        svint32_t q = svadd_s32_x(pg, numers,
+            svand_s32_x(pg, libdivide_s32_sve_signbits(numers), svdup_n_s32((int32_t)mask)));
+        q = libdivide_s32_sve_sra(q, shift);
+
+        // flip sign if divisor was negative
+        svint32_t sign = svdup_n_s32((int8_t)more >> 7);
+        return svsub_s32_x(pg, sveor_s32_x(pg, q, sign), sign);
+    }
+
+    // magic multiply-high path
+    svint32_t q = svmulh_n_s32_x(pg, numers, denom->magic);
+    if (more & LIBDIVIDE_ADD_MARKER) {
+        // add numers back, adjusted for divisor sign
+        svint32_t sign = svdup_n_s32((int8_t)more >> 7);
+        q = svadd_s32_x(pg, q, svsub_s32_x(pg, sveor_s32_x(pg, numers, sign), sign));
+    }
+    q = libdivide_s32_sve_sra(q, more & LIBDIVIDE_32_SHIFT_MASK);
+    // round toward zero
+    return svsub_s32_x(pg, q, libdivide_s32_sve_signbits(q));
+}
+
+svint32_t libdivide_s32_branchfree_do_sve(
+    svint32_t numers, const struct libdivide_s32_branchfree_t *denom) {
+    svbool_t pg = svptrue_b32();
+    int32_t magic = denom->magic;
+    uint8_t more = denom->more;
+    uint8_t shift = more & LIBDIVIDE_32_SHIFT_MASK;
+    svint32_t sign = svdup_n_s32((int8_t)more >> 7);
+    // branchfree starts with q = mullhi(numers, magic) + numers
+    svint32_t q = svmulh_n_s32_x(pg, numers, magic);
+    q = svadd_s32_x(pg, q, numers);
+    uint32_t is_power_of_2 = (magic == 0);
+    uint32_t mask = ((uint32_t)1 << shift) - is_power_of_2;
+    svint32_t mask_vec = svdup_n_s32((int32_t)mask);
+    // negative q needs a bias before arithmetic shift
+    q = svadd_s32_x(pg, q, svand_s32_x(pg, libdivide_s32_sve_signbits(q), mask_vec));
+    q = libdivide_s32_sve_sra(q, shift);
+    return svsub_s32_x(pg, sveor_s32_x(pg, q, sign), sign);
+}
+
+////////// SINT64
+
+svint64_t libdivide_s64_do_sve(svint64_t numers, const struct libdivide_s64_t *denom) {
+    svbool_t pg = svptrue_b64();
+    uint8_t more = denom->more;
+    int64_t magic = denom->magic;
+
+    // power of 2 path
+    if (magic == 0) {
+        uint8_t shift = more & LIBDIVIDE_64_SHIFT_MASK;
+        uint64_t mask = ((uint64_t)1 << shift) - 1;
+
+        // q = (numers + ((numers < 0) ? mask : 0)) >> shift
+        svint64_t q = svadd_s64_x(pg, numers,
+            svand_s64_x(pg, libdivide_s64_sve_signbits(numers), svdup_n_s64((int64_t)mask)));
+        q = libdivide_s64_sve_sra(q, shift);
+
+        // flip sign if divisor was negative
+        svint64_t sign = svdup_n_s64((int8_t)more >> 7);
+        return svsub_s64_x(pg, sveor_s64_x(pg, q, sign), sign);
+    }
+
+    // magic multiply-high path
+    svint64_t q = svmulh_n_s64_x(pg, numers, magic);
+    if (more & LIBDIVIDE_ADD_MARKER) {
+        // add numers back, adjusted for divisor sign
+        svint64_t sign = svdup_n_s64((int8_t)more >> 7);
+        q = svadd_s64_x(pg, q, svsub_s64_x(pg, sveor_s64_x(pg, numers, sign), sign));
+    }
+    q = libdivide_s64_sve_sra(q, more & LIBDIVIDE_64_SHIFT_MASK);
+    // round toward zero
+    return svsub_s64_x(pg, q, libdivide_s64_sve_signbits(q));
+}
+
+svint64_t libdivide_s64_branchfree_do_sve(
+    svint64_t numers, const struct libdivide_s64_branchfree_t *denom) {
+    svbool_t pg = svptrue_b64();
+    int64_t magic = denom->magic;
+    uint8_t more = denom->more;
+    uint8_t shift = more & LIBDIVIDE_64_SHIFT_MASK;
+    svint64_t sign = svdup_n_s64((int8_t)more >> 7);
+    // branchfree starts with q = mullhi(numers, magic) + numers
+    svint64_t q = svmulh_n_s64_x(pg, numers, magic);
+    q = svadd_s64_x(pg, q, numers);
+    uint64_t is_power_of_2 = (magic == 0);
+    svint64_t mask = svdup_n_s64((int64_t)(((uint64_t)1 << shift) - is_power_of_2));
+    // negative q needs a bias before arithmetic shift
+    q = svadd_s64_x(pg, q, svand_s64_x(pg, libdivide_s64_sve_signbits(q), mask));
+    q = libdivide_s64_sve_sra(q, shift);
+    return svsub_s64_x(pg, sveor_s64_x(pg, q, sign), sign);
+}
+
+#endif
+
 #if defined(LIBDIVIDE_AVX512)
 
 static LIBDIVIDE_INLINE __m512i libdivide_u16_do_vec512(
@@ -3122,6 +3463,56 @@ struct NeonVecFor {
 #define LIBDIVIDE_DIVIDE_NEON(ALGO, INT_TYPE)
 #endif
 
+#if defined(LIBDIVIDE_SVE)
+// Helper to deduce SVE vector type for integral type.
+template <int _WIDTH, Signedness _SIGN>
+struct SveVec {};
+
+template <>
+struct SveVec<16, UNSIGNED> {
+    typedef svuint16_t type;
+};
+
+template <>
+struct SveVec<16, SIGNED> {
+    typedef svint16_t type;
+};
+
+template <>
+struct SveVec<32, UNSIGNED> {
+    typedef svuint32_t type;
+};
+
+template <>
+struct SveVec<32, SIGNED> {
+    typedef svint32_t type;
+};
+
+template <>
+struct SveVec<64, UNSIGNED> {
+    typedef svuint64_t type;
+};
+
+template <>
+struct SveVec<64, SIGNED> {
+    typedef svint64_t type;
+};
+
+template <typename T>
+struct SveVecFor {
+    // See 'class divider' for an explanation of these template parameters.
+    typedef typename SveVec<sizeof(T) * 8, (((T)0 >> 0) > (T)(-1) ? SIGNED : UNSIGNED)>::type type;
+};
+
+#define LIBDIVIDE_DIVIDE_SVE(ALGO, INT_TYPE)                    \
+    LIBDIVIDE_INLINE typename SveVecFor<INT_TYPE>::type divide( \
+        typename SveVecFor<INT_TYPE>::type n) const {           \
+        return libdivide_##ALGO##_do_sve(n, &denom);            \
+    }
+#else
+#define LIBDIVIDE_DIVIDE_SVE(ALGO, INT_TYPE)
+#endif
+
 #if defined(LIBDIVIDE_SSE2)
 #define LIBDIVIDE_DIVIDE_SSE2(ALGO)                     \
     LIBDIVIDE_INLINE __m128i divide(__m128i n) const {  \
@@ -3159,6 +3550,7 @@ struct NeonVecFor {
     LIBDIVIDE_INLINE T divide(T n) const { return libdivide_##ALGO##_do(n, &denom); } \
     LIBDIVIDE_INLINE T recover() const { return libdivide_##ALGO##_recover(&denom); } \
     LIBDIVIDE_DIVIDE_NEON(ALGO, T)                                                    \
+    LIBDIVIDE_DIVIDE_SVE(ALGO, T)                                                     \
     LIBDIVIDE_DIVIDE_SSE2(ALGO)                                                       \
     LIBDIVIDE_DIVIDE_AVX2(ALGO)                                                       \
     LIBDIVIDE_DIVIDE_AVX512(ALGO)
@@ -3226,6 +3618,14 @@ struct NeonVecFor {
 };
 #endif
 
+#if defined(LIBDIVIDE_SVE)
+// Allow SveVecFor outside of detail namespace.
+template <typename T>
+struct SveVecFor {
+    typedef typename detail::SveVecFor<T>::type type;
+};
+#endif
+
 // This is the main divider class for use by the user (C++ API).
 // The actual division algorithm is selected using the dispatcher struct
 // based on the integer width and algorithm template parameters.
@@ -3279,6 +3679,11 @@ class divider {
 #endif
 #if defined(LIBDIVIDE_NEON)
     LIBDIVIDE_INLINE typename NeonVecFor<T>::type divide(typename NeonVecFor<T>::type n) const {
+        return div.divide(n);
+    }
+#endif
+#if defined(LIBDIVIDE_SVE)
+    LIBDIVIDE_INLINE typename SveVecFor<T>::type divide(typename SveVecFor<T>::type n) const {
         return div.divide(n);
     }
 #endif
@@ -3349,6 +3754,21 @@ LIBDIVIDE_INLINE typename NeonVecFor<T>::type operator/(
 template <typename T, Branching ALGO>
 LIBDIVIDE_INLINE typename NeonVecFor<T>::type operator/=(
     typename NeonVecFor<T>::type &n, const divider<T, ALGO> &div) {
+    n = div.divide(n);
+    return n;
+}
+#endif
+
+#if defined(LIBDIVIDE_SVE)
+template <typename T, Branching ALGO>
+LIBDIVIDE_INLINE typename SveVecFor<T>::type operator/(
+    typename SveVecFor<T>::type n, const divider<T, ALGO> &div) {
+    return div.divide(n);
+}
+
+template <typename T, Branching ALGO>
+LIBDIVIDE_INLINE typename SveVecFor<T>::type operator/=(
+    typename SveVecFor<T>::type &n, const divider<T, ALGO> &div) {
     n = div.divide(n);
     return n;
 }

--- a/test/DivideTest.h
+++ b/test/DivideTest.h
@@ -18,6 +18,7 @@ using set_t = std::numeric_limits<IntT>;
 #include <limits>
 #include <random>
 #include <string>
+#include <vector>
 typedef std::string string_class;
 #include <set>
 template <typename IntT>
@@ -39,8 +40,55 @@ using namespace libdivide;
 #define UNUSED(x) (void)(x)
 
 #if defined(LIBDIVIDE_SSE2) || defined(LIBDIVIDE_AVX2) || defined(LIBDIVIDE_AVX512) || \
-    defined(LIBDIVIDE_NEON)
+    defined(LIBDIVIDE_NEON) || defined(LIBDIVIDE_SVE)
 #define VECTOR_TESTS
+#endif
+
+#if defined(LIBDIVIDE_SVE)
+template <typename T>
+struct SveVecFuncs {};
+
+template <>
+struct SveVecFuncs<uint16_t> {
+    static size_t count() { return svcnth(); }
+    static svuint16_t load(const uint16_t *p) { return svld1_u16(svptrue_b16(), p); }
+    static void store(uint16_t *p, svuint16_t v) { svst1_u16(svptrue_b16(), p, v); }
+};
+
+template <>
+struct SveVecFuncs<int16_t> {
+    static size_t count() { return svcnth(); }
+    static svint16_t load(const int16_t *p) { return svld1_s16(svptrue_b16(), p); }
+    static void store(int16_t *p, svint16_t v) { svst1_s16(svptrue_b16(), p, v); }
+};
+
+template <>
+struct SveVecFuncs<uint32_t> {
+    static size_t count() { return svcntw(); }
+    static svuint32_t load(const uint32_t *p) { return svld1_u32(svptrue_b32(), p); }
+    static void store(uint32_t *p, svuint32_t v) { svst1_u32(svptrue_b32(), p, v); }
+};
+
+template <>
+struct SveVecFuncs<int32_t> {
+    static size_t count() { return svcntw(); }
+    static svint32_t load(const int32_t *p) { return svld1_s32(svptrue_b32(), p); }
+    static void store(int32_t *p, svint32_t v) { svst1_s32(svptrue_b32(), p, v); }
+};
+
+template <>
+struct SveVecFuncs<uint64_t> {
+    static size_t count() { return svcntd(); }
+    static svuint64_t load(const uint64_t *p) { return svld1_u64(svptrue_b64(), p); }
+    static void store(uint64_t *p, svuint64_t v) { svst1_u64(svptrue_b64(), p, v); }
+};
+
+template <>
+struct SveVecFuncs<int64_t> {
+    static size_t count() { return svcntd(); }
+    static svint64_t load(const int64_t *p) { return svld1_s64(svptrue_b64(), p); }
+    static void store(int64_t *p, svint64_t v) { svst1_s64(svptrue_b64(), p, v); }
+};
 #endif
 
 #ifdef _MSC_VER
@@ -172,6 +220,36 @@ class DivideTest {
         }
     }
 
+#if defined(LIBDIVIDE_SVE)
+    template <Branching ALGO>
+    void test_vec_sve(const T *numers, T denom, const divider<T, ALGO> &div) {
+        const size_t count = SveVecFuncs<T>::count();
+        typename SveVecFor<T>::type vec_in = SveVecFuncs<T>::load(numers);
+        typename SveVecFor<T>::type vec_result = vec_in / div;
+        std::vector<T> result(count);
+        SveVecFuncs<T>::store(result.data(), vec_result);
+
+        for (size_t i = 0; i < count; i++) {
+            T numer = numers[i];
+            T expect = numer / denom;
+            if (result[i] != expect) {
+                PRINT_ERROR(F("SVE vector failure for: "));
+                PRINT_ERROR(testcase_name(ALGO));
+                PRINT_ERROR(F(": "));
+                PRINT_ERROR(numer);
+                PRINT_ERROR(F(" / "));
+                PRINT_ERROR(denom);
+                PRINT_ERROR(F(" = "));
+                PRINT_ERROR(expect);
+                PRINT_ERROR(F(", but got "));
+                PRINT_ERROR(result[i]);
+                PRINT_ERROR(F("\n"));
+                TEST_FAIL();
+            }
+        }
+    }
+#endif
+
     // random_count * sizeof(T) must be >= size of largest
     // vector type. So figure that out at compile time.
     union vector_size_u {
@@ -295,6 +373,16 @@ class DivideTest {
             test_vec<typename NeonVecFor<T>::type>(numers, min_vector_count, denom, the_divider);
 #endif
         }
+#ifdef LIBDIVIDE_SVE
+        const size_t sve_count = SveVecFuncs<T>::count();
+        std::vector<T> sve_numers(sve_count);
+        for (size_t i = 0; i < 10000; ++i) {
+            for (size_t j = 0; j < sve_count; j++) {
+                sve_numers[j] = get_random();
+            }
+            test_vec_sve(sve_numers.data(), denom, the_divider);
+        }
+#endif
 #else
         UNUSED(denom);
         UNUSED(the_divider);

--- a/test/benchmark.h
+++ b/test/benchmark.h
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <limits>
 #include <type_traits>
+#include <vector>
 #endif
 
 #undef UNUSED
@@ -116,6 +117,92 @@ NOINLINE uint64_t sum_quotients_vec(const random_numerators<IntT> &vals, const D
         sumX4 = add_vector<sizeof(IntT)>(sumX4, numers);
     }
     return unsigned_sum_vals((const IntT *)&sumX4, count);
+}
+
+#elif defined(LIBDIVIDE_SVE)
+
+template <typename T>
+struct SveVecFuncs {};
+
+template <>
+struct SveVecFuncs<uint16_t> {
+    static inline size_t count() { return svcnth(); }
+    static inline svuint16_t dup(uint16_t value) { return svdup_n_u16(value); }
+    static inline svuint16_t load(const uint16_t *p) { return svld1_u16(svptrue_b16(), p); }
+    static inline svuint16_t add(svuint16_t a, svuint16_t b) {
+        return svadd_u16_x(svptrue_b16(), a, b);
+    }
+    static inline void store(uint16_t *p, svuint16_t v) { svst1_u16(svptrue_b16(), p, v); }
+};
+
+template <>
+struct SveVecFuncs<int16_t> {
+    static inline size_t count() { return svcnth(); }
+    static inline svint16_t dup(int16_t value) { return svdup_n_s16(value); }
+    static inline svint16_t load(const int16_t *p) { return svld1_s16(svptrue_b16(), p); }
+    static inline svint16_t add(svint16_t a, svint16_t b) {
+        return svadd_s16_x(svptrue_b16(), a, b);
+    }
+    static inline void store(int16_t *p, svint16_t v) { svst1_s16(svptrue_b16(), p, v); }
+};
+
+template <>
+struct SveVecFuncs<uint32_t> {
+    static inline size_t count() { return svcntw(); }
+    static inline svuint32_t dup(uint32_t value) { return svdup_n_u32(value); }
+    static inline svuint32_t load(const uint32_t *p) { return svld1_u32(svptrue_b32(), p); }
+    static inline svuint32_t add(svuint32_t a, svuint32_t b) {
+        return svadd_u32_x(svptrue_b32(), a, b);
+    }
+    static inline void store(uint32_t *p, svuint32_t v) { svst1_u32(svptrue_b32(), p, v); }
+};
+
+template <>
+struct SveVecFuncs<int32_t> {
+    static inline size_t count() { return svcntw(); }
+    static inline svint32_t dup(int32_t value) { return svdup_n_s32(value); }
+    static inline svint32_t load(const int32_t *p) { return svld1_s32(svptrue_b32(), p); }
+    static inline svint32_t add(svint32_t a, svint32_t b) {
+        return svadd_s32_x(svptrue_b32(), a, b);
+    }
+    static inline void store(int32_t *p, svint32_t v) { svst1_s32(svptrue_b32(), p, v); }
+};
+
+template <>
+struct SveVecFuncs<uint64_t> {
+    static inline size_t count() { return svcntd(); }
+    static inline svuint64_t dup(uint64_t value) { return svdup_n_u64(value); }
+    static inline svuint64_t load(const uint64_t *p) { return svld1_u64(svptrue_b64(), p); }
+    static inline svuint64_t add(svuint64_t a, svuint64_t b) {
+        return svadd_u64_x(svptrue_b64(), a, b);
+    }
+    static inline void store(uint64_t *p, svuint64_t v) { svst1_u64(svptrue_b64(), p, v); }
+};
+
+template <>
+struct SveVecFuncs<int64_t> {
+    static inline size_t count() { return svcntd(); }
+    static inline svint64_t dup(int64_t value) { return svdup_n_s64(value); }
+    static inline svint64_t load(const int64_t *p) { return svld1_s64(svptrue_b64(), p); }
+    static inline svint64_t add(svint64_t a, svint64_t b) {
+        return svadd_s64_x(svptrue_b64(), a, b);
+    }
+    static inline void store(int64_t *p, svint64_t v) { svst1_s64(svptrue_b64(), p, v); }
+};
+
+template <typename IntT, typename Divisor>
+NOINLINE uint64_t sum_quotients_vec(const random_numerators<IntT> &vals, const Divisor &div) {
+    typedef typename SveVecFor<IntT>::type SveVectorType;
+    size_t count = SveVecFuncs<IntT>::count();
+    SveVectorType sumX4 = SveVecFuncs<IntT>::dup(0);
+    for (auto iter = vals.begin(); iter != vals.end(); iter += count) {
+        SveVectorType numers = SveVecFuncs<IntT>::load(iter);
+        numers = numers / div;
+        sumX4 = SveVecFuncs<IntT>::add(sumX4, numers);
+    }
+    std::vector<IntT> sum(count);
+    SveVecFuncs<IntT>::store(sum.data(), sumX4);
+    return unsigned_sum_vals(sum.data(), count);
 }
 
 #elif defined(LIBDIVIDE_NEON)
@@ -254,7 +341,7 @@ NOINLINE TestResult test_one(const random_numerators<IntT> &vals, IntT denom) {
             check_result(tresult.result, expected, __LINE__);
         }
 
-#if defined(x86_VECTOR_TYPE) || defined(LIBDIVIDE_NEON)
+#if defined(x86_VECTOR_TYPE) || defined(LIBDIVIDE_SVE) || defined(LIBDIVIDE_NEON)
         tresult = time_function(vals, div_bfull, sum_quotients_vec);
         min_my_time_vector = (std::min)(min_my_time_vector, tresult.time);
         check_result(tresult.result, expected, __LINE__);

--- a/test/tester.cpp
+++ b/test/tester.cpp
@@ -114,6 +114,9 @@ int main(int argc, char *argv[]) {
 #if defined(LIBDIVIDE_NEON)
     vecTypes += "neon ";
 #endif
+#if defined(LIBDIVIDE_SVE)
+    vecTypes += "sve ";
+#endif
     if (vecTypes.empty()) {
         vecTypes = "none ";
     }


### PR DESCRIPTION
Adds an ARM SVE backend for libdivide.

- Adds `LIBDIVIDE_SVE` C/C++ vector division for 16/32/64-bit signed and unsigned types
- Supports branchy and branchfree dividers
- Wires SVE into CMake, tester, and benchmark support

Tested on AWS Graviton4 / Neoverse V2 (which supports 128-bit SVE), with `ctest --tests-regex tester`.
Also tested on QEMU for SVE128, SVE256 and SVE512 compatibility.

Performance, in ns per value:

| Type | Divisors | Hardware | Scalar | Scalar BF | NEON | NEON BF | **SVE** | **SVE BF** |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| u16 | 31 | 2050.9 | 765.6 | 940.8 | 465.6 | 687.6 | **90.9** | **97.2** |
| s16 | 37 | 2058.2 | 847.0 | 1213.3 | 635.7 | 925.4 | **99.4** | **148.0** |
| u32 | 31 | 2303.3 | 670.9 | 774.8 | 200.8 | 221.5 | **185.5** | **191.6** |
| s32 | 37 | 2386.7 | 751.6 | 1061.3 | 228.4 | 388.3 | **203.6** | **299.0** |
| u64 | 31 | 4720.7 | 598.0 | 647.4 | 1069.5 | 1295.8 | **359.3** | **359.1** |
| s64 | 37 | 4752.5 | 687.1 | 999.0 | 1350.9 | 1920.0 | **399.9** | **637.6** |

Big win for 16-bit, where SVE has a native SIMD path, and for 64-bit, where SVE can use vector multiply high.