### PR TITLE
SVE and SVE2 optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(LIBDIVIDE_AVX2  AUTO CACHE STRING  "Enable AVX2 vector instructions")
 set(LIBDIVIDE_AVX512 AUTO CACHE STRING "Enable AVX512 vector instructions")
 set(LIBDIVIDE_NEON AUTO CACHE STRING "Enable ARM NEON vector instructions")
 set(LIBDIVIDE_SVE  AUTO CACHE STRING  "Enable ARM SVE vector instructions")
+set(LIBDIVIDE_SVE2 AUTO CACHE STRING  "Enable ARM SVE2 vector instructions")
 
 # By default enable release mode ###############################
 
@@ -204,6 +205,30 @@ else()
     endif()
 endif()
 
+# SVE2
+if (NOT LIBDIVIDE_SVE2 STREQUAL "AUTO")
+    set(LIBDIVIDE_SVE2_ENABLED "${LIBDIVIDE_SVE2}")
+else()
+    set(SVE2_TEST "
+    #include <arm_sve.h>
+    int main()
+    {
+        svbool_t pg = svptrue_b32();
+        svuint32_t a = svdup_n_u32(0);
+        svuint32_t b = svhadd_u32_x(pg, a, a);
+        return (int)svlastb_u32(pg, b);
+    }")
+    if (CMAKE_CROSSCOMPILING)
+        check_cxx_source_compiles("${SVE2_TEST}" LIBDIVIDE_SVE2_ENABLED)
+    else()
+        check_cxx_source_runs("${SVE2_TEST}" LIBDIVIDE_SVE2_ENABLED)
+    endif()
+endif()
+
+if(LIBDIVIDE_SVE2_ENABLED)
+    set(LIBDIVIDE_SVE_ENABLED TRUE)
+endif()
+
 # AVX512
 if (NOT LIBDIVIDE_AVX512 STREQUAL "AUTO")
     set(LIBDIVIDE_AVX512_ENABLED "${LIBDIVIDE_AVX512}")
@@ -256,6 +281,9 @@ if(LIBDIVIDE_NEON_ENABLED)
 endif()
 if(LIBDIVIDE_SVE_ENABLED)
     list(APPEND LIBDIVIDE_VECTOR_EXT "LIBDIVIDE_SVE")
+endif()
+if(LIBDIVIDE_SVE2_ENABLED)
+    list(APPEND LIBDIVIDE_VECTOR_EXT "LIBDIVIDE_SVE2")
 endif()
 if(LIBDIVIDE_AVX512_ENABLED)
     list(APPEND LIBDIVIDE_VECTOR_EXT "LIBDIVIDE_AVX512")

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Note that you need to define one of macros below to enable vector division:
 * ```LIBDIVIDE_AVX512```
 * ```LIBDIVIDE_NEON```
 * ```LIBDIVIDE_SVE```
+* ```LIBDIVIDE_SVE2```
 
 ## Performance Tips
 

--- a/doc/C-API.md
+++ b/doc/C-API.md
@@ -83,7 +83,8 @@ svint64_t libdivide_s64_branchfree_do_sve(svint64_t numers, const struct libdivi
 ```
 
 You need to define ```LIBDIVIDE_SVE``` and compile for a target with Arm SVE
-support to enable SVE vector division.
+support to enable SVE vector division. ```LIBDIVIDE_SVE2``` enables SVE2-specific
+instructions where libdivide can use them, and implies ```LIBDIVIDE_SVE```.
 
 ## libdivide SSE2 vector division
 

--- a/doc/CPP-API.md
+++ b/doc/CPP-API.md
@@ -123,7 +123,8 @@ svint64_t operator/=(svint64_t &n, const divider<int64_t, ALGO> &div)
 ```
 
 You need to define ```LIBDIVIDE_SVE``` and compile for a target with Arm SVE
-support to enable SVE vector division.
+support to enable SVE vector division. ```LIBDIVIDE_SVE2``` enables SVE2-specific
+instructions where libdivide can use them, and implies ```LIBDIVIDE_SVE```.
 
 ## SSE2 vector division
 

--- a/libdivide.h
+++ b/libdivide.h
@@ -44,6 +44,10 @@
 #include <arm_neon.h>
 #endif
 
+#if defined(LIBDIVIDE_SVE2) && !defined(LIBDIVIDE_SVE)
+#define LIBDIVIDE_SVE
+#endif
+
 #if defined(LIBDIVIDE_SVE)
 #include <arm_sve.h>
 #endif
@@ -2152,21 +2156,30 @@ static LIBDIVIDE_INLINE svint64_t libdivide_s64_sve_sra(svint64_t v, uint8_t amt
     return svasr_n_s64_x(svptrue_b64(), v, amt);
 }
 
-// unsigned halving subtract: (x - y) >> 1
-// SVE2 has svhsub_u*_x() for this operation, could be useful later
-static LIBDIVIDE_INLINE svuint16_t libdivide_u16_sve_hsub(svuint16_t x, svuint16_t y) {
+// unsigned halving add: (x + y) >> 1
+static LIBDIVIDE_INLINE svuint16_t libdivide_u16_sve_hadd(svuint16_t x, svuint16_t y) {
     svbool_t pg = svptrue_b16();
-    return svlsr_n_u16_x(pg, svsub_u16_x(pg, x, y), 1);
+#if defined(LIBDIVIDE_SVE2)
+    return svhadd_u16_x(pg, x, y);
+#else
+    return svadd_u16_x(pg, svlsr_n_u16_x(pg, svsub_u16_x(pg, x, y), 1), y);
+#endif
 }
 
-static LIBDIVIDE_INLINE svuint32_t libdivide_u32_sve_hsub(svuint32_t x, svuint32_t y) {
+static LIBDIVIDE_INLINE svuint32_t libdivide_u32_sve_hadd(svuint32_t x, svuint32_t y) {
     svbool_t pg = svptrue_b32();
-    return svlsr_n_u32_x(pg, svsub_u32_x(pg, x, y), 1);
+#if defined(LIBDIVIDE_SVE2)
+    return svhadd_u32_x(pg, x, y);
+#else
+    return svadd_u32_x(pg, svlsr_n_u32_x(pg, svsub_u32_x(pg, x, y), 1), y);
+#endif
 }
 
-static LIBDIVIDE_INLINE svuint64_t libdivide_u64_sve_hsub(svuint64_t x, svuint64_t y) {
+static LIBDIVIDE_INLINE svuint64_t libdivide_u64_sve_hadd(svuint64_t x, svuint64_t y) {
     svbool_t pg = svptrue_b64();
-    return svlsr_n_u64_x(pg, svsub_u64_x(pg, x, y), 1);
+    // SVE2 has svhadd_u64_x, but it was neutral to slower on Graviton4.
+    // Keep the base SVE sequence for the 64-bit add-marker path.
+    return svadd_u64_x(pg, svlsr_n_u64_x(pg, svsub_u64_x(pg, x, y), 1), y);
 }
 
 // sign mask: 0 for non-negative lanes, -1 for negative lanes
@@ -2195,9 +2208,9 @@ svuint16_t libdivide_u16_do_sve(svuint16_t numers, const struct libdivide_u16_t 
 
     svuint16_t q = svmulh_n_u16_x(pg, numers, denom->magic);
     if (more & LIBDIVIDE_ADD_MARKER) {
-        // t = ((numers - q) >> 1) + q
+        // t = (numers + q) >> 1
         uint8_t shift = more & LIBDIVIDE_16_SHIFT_MASK;
-        svuint16_t t = svadd_u16_x(pg, libdivide_u16_sve_hsub(numers, q), q);
+        svuint16_t t = libdivide_u16_sve_hadd(numers, q);
         return libdivide_u16_sve_srl(t, shift);
     }
 
@@ -2209,7 +2222,7 @@ svuint16_t libdivide_u16_branchfree_do_sve(
     svbool_t pg = svptrue_b16();
     // branchfree always uses the add-marker correction
     svuint16_t q = svmulh_n_u16_x(pg, numers, denom->magic);
-    svuint16_t t = svadd_u16_x(pg, libdivide_u16_sve_hsub(numers, q), q);
+    svuint16_t t = libdivide_u16_sve_hadd(numers, q);
     return libdivide_u16_sve_srl(t, denom->more);
 }
 
@@ -2226,9 +2239,9 @@ svuint32_t libdivide_u32_do_sve(svuint32_t numers, const struct libdivide_u32_t 
 
     svuint32_t q = svmulh_n_u32_x(pg, numers, denom->magic);
     if (more & LIBDIVIDE_ADD_MARKER) {
-        // t = ((numers - q) >> 1) + q
+        // t = (numers + q) >> 1
         uint8_t shift = more & LIBDIVIDE_32_SHIFT_MASK;
-        svuint32_t t = svadd_u32_x(pg, libdivide_u32_sve_hsub(numers, q), q);
+        svuint32_t t = libdivide_u32_sve_hadd(numers, q);
         return libdivide_u32_sve_srl(t, shift);
     }
 
@@ -2240,7 +2253,7 @@ svuint32_t libdivide_u32_branchfree_do_sve(
     svbool_t pg = svptrue_b32();
     // branchfree always uses the add-marker correction
     svuint32_t q = svmulh_n_u32_x(pg, numers, denom->magic);
-    svuint32_t t = svadd_u32_x(pg, libdivide_u32_sve_hsub(numers, q), q);
+    svuint32_t t = libdivide_u32_sve_hadd(numers, q);
     return libdivide_u32_sve_srl(t, denom->more);
 }
 
@@ -2257,9 +2270,9 @@ svuint64_t libdivide_u64_do_sve(svuint64_t numers, const struct libdivide_u64_t 
 
     svuint64_t q = svmulh_n_u64_x(pg, numers, denom->magic);
     if (more & LIBDIVIDE_ADD_MARKER) {
-        // t = ((numers - q) >> 1) + q
+        // t = (numers + q) >> 1
         uint8_t shift = more & LIBDIVIDE_64_SHIFT_MASK;
-        svuint64_t t = svadd_u64_x(pg, libdivide_u64_sve_hsub(numers, q), q);
+        svuint64_t t = libdivide_u64_sve_hadd(numers, q);
         return libdivide_u64_sve_srl(t, shift);
     }
 
@@ -2271,7 +2284,7 @@ svuint64_t libdivide_u64_branchfree_do_sve(
     svbool_t pg = svptrue_b64();
     // branchfree always uses the add-marker correction
     svuint64_t q = svmulh_n_u64_x(pg, numers, denom->magic);
-    svuint64_t t = svadd_u64_x(pg, libdivide_u64_sve_hsub(numers, q), q);
+    svuint64_t t = libdivide_u64_sve_hadd(numers, q);
     return libdivide_u64_sve_srl(t, denom->more);
 }
 
@@ -2287,8 +2300,8 @@ svint16_t libdivide_s16_do_sve(svint16_t numers, const struct libdivide_s16_t *d
         uint16_t mask = ((uint16_t)1 << shift) - 1;
 
         // q = (numers + ((numers < 0) ? mask : 0)) >> shift
-        svint16_t q = svadd_s16_x(pg, numers,
-            svand_s16_x(pg, libdivide_s16_sve_signbits(numers), svdup_n_s16((int16_t)mask)));
+        svint16_t q =
+            svadd_s16_m(svcmplt_n_s16(pg, numers, 0), numers, svdup_n_s16((int16_t)mask));
         q = libdivide_s16_sve_sra(q, shift);
 
         // flip sign if divisor was negative
@@ -2322,7 +2335,7 @@ svint16_t libdivide_s16_branchfree_do_sve(
     uint32_t mask = ((uint32_t)1 << shift) - is_power_of_2;
     svint16_t mask_vec = svdup_n_s16((int16_t)mask);
     // negative q needs a bias before arithmetic shift
-    q = svadd_s16_x(pg, q, svand_s16_x(pg, libdivide_s16_sve_signbits(q), mask_vec));
+    q = svadd_s16_m(svcmplt_n_s16(pg, q, 0), q, mask_vec);
     q = libdivide_s16_sve_sra(q, shift);
     return svsub_s16_x(pg, sveor_s16_x(pg, q, sign), sign);
 }
@@ -2339,8 +2352,8 @@ svint32_t libdivide_s32_do_sve(svint32_t numers, const struct libdivide_s32_t *d
         uint32_t mask = ((uint32_t)1 << shift) - 1;
 
         // q = (numers + ((numers < 0) ? mask : 0)) >> shift
-        svint32_t q = svadd_s32_x(pg, numers,
-            svand_s32_x(pg, libdivide_s32_sve_signbits(numers), svdup_n_s32((int32_t)mask)));
+        svint32_t q =
+            svadd_s32_m(svcmplt_n_s32(pg, numers, 0), numers, svdup_n_s32((int32_t)mask));
         q = libdivide_s32_sve_sra(q, shift);
 
         // flip sign if divisor was negative
@@ -2374,7 +2387,7 @@ svint32_t libdivide_s32_branchfree_do_sve(
     uint32_t mask = ((uint32_t)1 << shift) - is_power_of_2;
     svint32_t mask_vec = svdup_n_s32((int32_t)mask);
     // negative q needs a bias before arithmetic shift
-    q = svadd_s32_x(pg, q, svand_s32_x(pg, libdivide_s32_sve_signbits(q), mask_vec));
+    q = svadd_s32_m(svcmplt_n_s32(pg, q, 0), q, mask_vec);
     q = libdivide_s32_sve_sra(q, shift);
     return svsub_s32_x(pg, sveor_s32_x(pg, q, sign), sign);
 }
@@ -2392,8 +2405,8 @@ svint64_t libdivide_s64_do_sve(svint64_t numers, const struct libdivide_s64_t *d
         uint64_t mask = ((uint64_t)1 << shift) - 1;
 
         // q = (numers + ((numers < 0) ? mask : 0)) >> shift
-        svint64_t q = svadd_s64_x(pg, numers,
-            svand_s64_x(pg, libdivide_s64_sve_signbits(numers), svdup_n_s64((int64_t)mask)));
+        svint64_t q =
+            svadd_s64_m(svcmplt_n_s64(pg, numers, 0), numers, svdup_n_s64((int64_t)mask));
         q = libdivide_s64_sve_sra(q, shift);
 
         // flip sign if divisor was negative
@@ -2426,7 +2439,7 @@ svint64_t libdivide_s64_branchfree_do_sve(
     uint64_t is_power_of_2 = (magic == 0);
     svint64_t mask = svdup_n_s64((int64_t)(((uint64_t)1 << shift) - is_power_of_2));
     // negative q needs a bias before arithmetic shift
-    q = svadd_s64_x(pg, q, svand_s64_x(pg, libdivide_s64_sve_signbits(q), mask));
+    q = svadd_s64_m(svcmplt_n_s64(pg, q, 0), q, mask);
     q = libdivide_s64_sve_sra(q, shift);
     return svsub_s64_x(pg, sveor_s64_x(pg, q, sign), sign);
 }

--- a/test/tester.cpp
+++ b/test/tester.cpp
@@ -117,6 +117,9 @@ int main(int argc, char *argv[]) {
 #if defined(LIBDIVIDE_SVE)
     vecTypes += "sve ";
 #endif
+#if defined(LIBDIVIDE_SVE2)
+    vecTypes += "sve2 ";
+#endif
     if (vecTypes.empty()) {
         vecTypes = "none ";
     }


### PR DESCRIPTION
Optimizes the existing Arm SVE backend and adds an optional SVE2 path.

- Uses SVE predicated merge-adds for the signed bias step
- Adds `LIBDIVIDE_SVE2`, which implies `LIBDIVIDE_SVE`
- Uses SVE2 `svhadd_u16_x` / `svhadd_u32_x` for unsigned add-marker correction
- Wires SVE2 into CMake autodetection, tester reporting, and docs

Tested on AWS Graviton4 / Neoverse V2 with GCC and Clang: `tester u16 s16 u32 s32 u64 s64` and `test_c99`.

Performance, ns/value, lower is better.

Base SVE merge-add cleanup:

| Type | Divisors Tested | Old SVE | New SVE | Speedup | Old SVE BF | New SVE BF | Speedup BF |
|---|---:|---:|---:|---:|---:|---:|---:|
| s16 | 32 | 103.9 | **101.8** | +2.0% | 147.9 | **134.5** | +9.1% |
| s32 | 32 | **201.8** | 204.0 | -1.1% | 304.1 | **264.8** | +12.9% |
| s64 | 32 | 434.3 | **425.1** | +2.1% | 645.9 | **594.0** | +8.0% |

The merge-add cleanup uses SVE predication to add the signed shift bias only in lanes where the intermediate quotient is negative, replacing a signbits-and-mask sequence.

SVE2 `svhadd` add-marker path:

| Type | Divisors Tested | SVE | SVE2 | Speedup | SVE BF | SVE2 BF | Speedup BF |
|---|---:|---:|---:|---:|---:|---:|---:|
| u16 | 32 | 91.6 | **89.8** | +2.0% | 95.2 | **89.4** | +6.2% |
| u32 | 32 | 186.1 | **183.4** | +1.4% | 192.8 | **187.0** | +3.0% |
| u64 | 32 | **370.4** | 371.9 | -0.4% | **372.5** | 376.9 | -1.2% |

SVE2 only intentionally changes unsigned 16/32-bit add-marker paths. The signed gains are from the base SVE merge-add cleanup; the 64-bit unsigned path keeps the base SVE sequence because `svhadd_u64_x` was neutral to slower on Graviton4.
