### PR TITLE
Windows 2019 deprecated in Github Actions - replaced with Windows 2025

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -66,7 +66,7 @@ jobs:
       matrix:
         os:
           - windows-2022
-          - windows-2019
+          - windows-2025
         build_type:
           - Release
           - Sanitize
@@ -79,8 +79,8 @@ jobs:
           # See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
           - os: windows-2022
             generator: Visual Studio 17 2022
-          - os: windows-2019
-            generator: Visual Studio 16 2019
+          - os: windows-2025
+            generator: Visual Studio 17 2022
           # clang-cl requires the toolset flag be set correctly 
           - cpp_compiler: clang-cl.exe
             toolset: ClangCL            


### PR DESCRIPTION
Windows 2019 has been deprecated for GitHub Actions hosted runners:
https://github.com/actions/runner-images/issues/12045

This updates the Windows CI matrix to use `windows-2025` instead of `windows-2019`, with the Visual Studio generator updated from `Visual Studio 16 2019` to `Visual Studio 17 2022`.