### PR TITLE
Fix Windows CI failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,16 @@ if (WARN_VEC_CONVERSIONS)
     list(APPEND LIBDIVIDE_FLAGS "-fno-lax-vector-conversions")
 endif()
 
+set(LIBDIVIDE_BENCHMARK_DIVLU_FLAGS "${LIBDIVIDE_FLAGS}")
+# benchmark_divlu uses a deliberate non-standard extension in its timing harness.
+# Suppress that warning only for compilers that accept GCC-style warning flags.
+if (NOT CMAKE_C_COMPILER_ID STREQUAL "MSVC" AND NOT CMAKE_C_SIMULATE_ID STREQUAL "MSVC")
+    check_c_compiler_flag("-Wno-pedantic" WNO_PEDANTIC)
+    if (WNO_PEDANTIC)
+        list(APPEND LIBDIVIDE_BENCHMARK_DIVLU_FLAGS "-Wno-pedantic")
+    endif()
+endif()
+
 
 # Check native CPU family ######################################
 
@@ -322,7 +332,7 @@ if (LIBDIVIDE_BUILD_TESTS)
     target_compile_options(tester PRIVATE "${LIBDIVIDE_FLAGS}" "${NO_VECTORIZE}")
     target_compile_options(test_c99 PRIVATE "${LIBDIVIDE_FLAGS}" "${NO_VECTORIZE}")
     target_compile_options(test_divlu PRIVATE "${LIBDIVIDE_FLAGS}")
-    target_compile_options(benchmark_divlu PRIVATE "${LIBDIVIDE_FLAGS}" "-Wno-pedantic")
+    target_compile_options(benchmark_divlu PRIVATE "${LIBDIVIDE_BENCHMARK_DIVLU_FLAGS}")
     target_compile_options(fast_div_generator PRIVATE "${LIBDIVIDE_FLAGS}" "${NO_VECTORIZE}")
     target_compile_options(benchmark PRIVATE "${LIBDIVIDE_FLAGS}" "${NO_VECTORIZE_C}")
     target_compile_options(benchmark_branchfree PRIVATE "${LIBDIVIDE_FLAGS}" "${NO_VECTORIZE}")

--- a/doc/divlu.c
+++ b/doc/divlu.c
@@ -2,6 +2,37 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+// Use a small wrapper for leading-zero counts so this file can build with MSVC.
+// GCC and Clang provide __builtin_clz*, while MSVC exposes the operation via intrinsics.
+#if defined(_MSC_VER)
+#include <intrin.h>
+
+static int divlu_count_leading_zeros32(uint32_t x)
+{
+    unsigned long index;
+    _BitScanReverse(&index, x);
+    return 31 - (int)index;
+}
+
+static int divlu_count_leading_zeros64(uint64_t x)
+{
+    uint32_t high = (uint32_t)(x >> 32);
+    if (high != 0)
+        return divlu_count_leading_zeros32(high);
+    return 32 + divlu_count_leading_zeros32((uint32_t)x);
+}
+#else
+static int divlu_count_leading_zeros32(uint32_t x)
+{
+    return __builtin_clz(x);
+}
+
+static int divlu_count_leading_zeros64(uint64_t x)
+{
+    return __builtin_clzll(x);
+}
+#endif
+
 /*
  * Perform a narrowing division: 128 / 64 -> 64, and 64 / 32 -> 32.
  * The dividend's low and high words are given by \p numhi and \p numlo, respectively.
@@ -66,7 +97,7 @@ uint64_t divllu(uint64_t numhi, uint64_t numlo, uint64_t den, uint64_t *r)
     // The expression (-shift & 63) is the same as (64 - shift), except it avoids the UB of shifting
     // by 64. The funny bitwise 'and' ensures that numlo does not get shifted into numhi if shift is 0.
     // clang 11 has an x86 codegen bug here: see LLVM bug 50118. The sequence below avoids it.
-    shift = __builtin_clzll(den);
+    shift = divlu_count_leading_zeros64(den);
     den <<= shift;
     numhi <<= shift;
     numhi |= (numlo >> (-shift & 63)) & (-(int64_t)shift >> 63);
@@ -164,7 +195,7 @@ uint32_t divlu(uint32_t numhi, uint32_t numlo, uint32_t den, uint32_t *r)
     // The expression (-shift & 31) is the same as (32 - shift), except it avoids the UB of shifting
     // by 32. The funny bitwise 'and' ensures that numlo does not get shifted into numhi if shift is 0.
     // clang 11 has an x86 codegen bug here: see LLVM bug 50118. The sequence below avoids it.
-    shift = __builtin_clz(den);
+    shift = divlu_count_leading_zeros32(den);
     den <<= shift;
     numhi <<= shift;
     numhi |= (numlo >> (-shift & 31)) & (-(int32_t)shift >> 31);
@@ -207,4 +238,3 @@ uint32_t divlu(uint32_t numhi, uint32_t numlo, uint32_t den, uint32_t *r)
         *r = num10 - q * den10;
     return q;
 }
-

--- a/test/benchmark_divlu.c
+++ b/test/benchmark_divlu.c
@@ -7,6 +7,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#if defined(_WIN32)
+#include <windows.h>
+#endif
 
 uint32_t divlu(uint32_t numhi, uint32_t numlo, uint32_t den, uint32_t *r);
 uint64_t divllu(uint64_t numhi, uint64_t numlo, uint64_t den, uint64_t *r);
@@ -17,9 +20,19 @@ uint64_t divllu(uint64_t numhi, uint64_t numlo, uint64_t den, uint64_t *r);
 typedef unsigned long long ullong;
 
 static uint64_t now_ns(void) {
+#if defined(_WIN32)
+    // clock_gettime is not available under MSVC; use the Windows monotonic timer.
+    static LARGE_INTEGER frequency;
+    LARGE_INTEGER counter;
+    if (frequency.QuadPart == 0)
+        QueryPerformanceFrequency(&frequency);
+    QueryPerformanceCounter(&counter);
+    return (uint64_t)((double)counter.QuadPart * 1000000000.0 / (double)frequency.QuadPart);
+#else
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (uint64_t)ts.tv_sec * UINT64_C(1000000000) + (uint64_t)ts.tv_nsec;
+#endif
 }
 
 // xorshift64 RNG.
@@ -144,6 +157,8 @@ int main(void) {
             abort();
         }
 #else
+        // r_hw128 is only used when the compiler supports the __int128 reference path.
+        (void)r_hw128;
         t_hw128 = 0;
 #endif
 


### PR DESCRIPTION
Fixes the current Windows CI failures without changing the division algorithms.

- `CMakeLists.txt`
  - Stops passing `-Wno-pedantic` to MSVC-style compilers for `benchmark_divlu`
  - Checks whether the C compiler supports `-Wno-pedantic` before adding it

- `doc/divlu.c`
  - Replaces direct `__builtin_clz` / `__builtin_clzll` calls with helper functions
  - Keeps the GCC/Clang builtin path
  - Uses `_BitScanReverse` on MSVC

- `test/benchmark_divlu.c`
  - Adds a Windows timer path using `QueryPerformanceCounter`
  - Keeps `clock_gettime(CLOCK_MONOTONIC, ...)` for non-Windows
  - Marks `r_hw128` unused when the `__int128` reference path is unavailable, avoiding `/WX` failures